### PR TITLE
add level meter to portapack ui

### DIFF
--- a/firmware/common/hackrf_ui.c
+++ b/firmware/common/hackrf_ui.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2019-2022 Great Scott Gadgets <info@greatscottgadgets.com>
  * Copyright (C) 2019 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright 2024 Bernd Herzog
  *
  * This file is part of HackRF.
  *

--- a/firmware/common/hackrf_ui.c
+++ b/firmware/common/hackrf_ui.c
@@ -47,6 +47,7 @@ void hackrf_ui_set_antenna_bias_null(bool antenna_bias) { UNUSED(antenna_bias); 
 void hackrf_ui_set_clock_source_null(clock_source_t source) { UNUSED(source); }
 void hackrf_ui_set_transceiver_mode_null(transceiver_mode_t mode) { UNUSED(mode); }
 bool hackrf_ui_operacake_gpio_compatible_null(void) { return true; }
+void hackrf_ui_set_saturation_null(const uint8_t saturation) { UNUSED(saturation); }
 
 // clang-format on
 
@@ -69,7 +70,8 @@ static const hackrf_ui_t hackrf_ui_null = {
 	&hackrf_ui_set_antenna_bias_null,
 	&hackrf_ui_set_clock_source_null,
 	&hackrf_ui_set_transceiver_mode_null,
-	&hackrf_ui_operacake_gpio_compatible_null};
+	&hackrf_ui_operacake_gpio_compatible_null,
+	hackrf_ui_set_saturation_null};
 
 static const hackrf_ui_t* ui = NULL;
 static bool ui_enabled = true;

--- a/firmware/common/hackrf_ui.h
+++ b/firmware/common/hackrf_ui.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2018-2022 Great Scott Gadgets <info@greatscottgadgets.com>
  * Copyright (C) 2018 Jared Boone, ShareBrained Technology, Inc.
+ * Copyright 2024 Bernd Herzog
  *
  * This file is part of HackRF.
  *

--- a/firmware/common/hackrf_ui.h
+++ b/firmware/common/hackrf_ui.h
@@ -42,6 +42,7 @@ typedef void (*hackrf_ui_set_antenna_bias_fn)(bool antenna_bias);
 typedef void (*hackrf_ui_set_clock_source_fn)(clock_source_t source);
 typedef void (*hackrf_ui_set_transceiver_mode_fn)(transceiver_mode_t mode);
 typedef bool (*hackrf_ui_operacake_gpio_compatible_fn)(void);
+typedef void (*hackrf_ui_set_saturation_fn)(const uint8_t saturation);
 
 typedef struct {
 	hackrf_ui_init_fn init;
@@ -60,6 +61,7 @@ typedef struct {
 	hackrf_ui_set_clock_source_fn set_clock_source;
 	hackrf_ui_set_transceiver_mode_fn set_transceiver_mode;
 	hackrf_ui_operacake_gpio_compatible_fn operacake_gpio_compatible;
+	hackrf_ui_set_saturation_fn set_saturation;
 } hackrf_ui_t;
 
 /* TODO: Lame hack to know that PortaPack was detected.

--- a/firmware/common/portapack.c
+++ b/firmware/common/portapack.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2018-2022 Great Scott Gadgets <info@greatscottgadgets.com>
  * Copyright 2018 Jared Boone
+ * Copyright 2024 Bernd Herzog
  *
  * This file is part of HackRF.
  *

--- a/firmware/common/ui_portapack.c
+++ b/firmware/common/ui_portapack.c
@@ -299,6 +299,7 @@ static const ui_bitmap_t bitmap_oscillator = {{24, 24}, bitmap_oscillator_data};
 static const uint8_t bitmap_wire_8_data[] = {0xff, 0xff};
 
 static const ui_bitmap_t bitmap_wire_8 = {{2, 8}, bitmap_wire_8_data};
+static const ui_bitmap_t bitmap_bar_8 = {{8, 2}, bitmap_wire_8_data};
 
 static const uint8_t bitmap_wire_24_data[] = {
 	0x00, 0x18, 0x00, 0x00, 0x18, 0x00, 0x00, 0x18, 0x00, 0x00, 0x18, 0x00,
@@ -346,7 +347,7 @@ __attribute__((unused)) static ui_color_t portapack_color_rgb(
 	return result;
 }
 
-static const ui_color_t color_background = {0x001f};
+static const ui_color_t color_background = {0x0000};
 static const ui_color_t color_foreground = {0xffff};
 
 static ui_point_t portapack_lcd_draw_int(
@@ -717,6 +718,34 @@ static bool portapack_ui_operacake_gpio_compatible(void)
 	return false;
 }
 
+static void portapack_ui_set_saturation(const uint8_t saturation)
+{
+	static const ui_color_t color_red = {0xF800};
+	static const ui_color_t color_orange = {0xfd20};
+	static const ui_color_t color_green = {0x07e0};
+
+	for (size_t i = 0; i < 125; i+=4)
+	{
+		ui_point_t label_point = {208, 128 + 125-i};
+		if (saturation > i)
+		{
+			portapack_draw_bitmap(
+				label_point,
+				bitmap_bar_8,
+				i < 100 ? color_green : (i < 115 ? color_orange : color_red),
+				color_background);
+		}
+		else
+		{
+			portapack_draw_bitmap(
+				label_point,
+				bitmap_bar_8,
+				color_background,
+				color_background);
+		}
+	}
+}
+
 const hackrf_ui_t portapack_hackrf_ui = {
 	&portapack_ui_init,
 	&portapack_ui_deinit,
@@ -734,6 +763,7 @@ const hackrf_ui_t portapack_hackrf_ui = {
 	&portapack_ui_set_clock_source,
 	&portapack_ui_set_transceiver_mode,
 	&portapack_ui_operacake_gpio_compatible,
+	&portapack_ui_set_saturation,
 };
 
 const hackrf_ui_t* portapack_hackrf_ui_init()

--- a/firmware/common/ui_portapack.c
+++ b/firmware/common/ui_portapack.c
@@ -1,6 +1,7 @@
 /*
  * Copyright 2018-2022 Great Scott Gadgets <info@greatscottgadgets.com>
  * Copyright 2018 Jared Boone
+ * Copyright 2024 Bernd Herzog
  *
  * This file is part of HackRF.
  *

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -28,6 +28,7 @@
 #include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/timer.h>
+#include <libopencm3/cm3/systick.h>
 
 #include <streaming.h>
 
@@ -243,6 +244,11 @@ int main(void)
 	enable_rf_power();
 #endif
 	cpu_clock_init();
+
+	systick_set_reload(2039999);
+	systick_set_clocksource(true);
+	systick_interrupt_enable();
+	systick_counter_enable();
 
 	/* Wake the M0 */
 	ipc_halt_m0();

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -2,6 +2,7 @@
  * Copyright 2012-2022 Great Scott Gadgets <info@greatscottgadgets.com>
  * Copyright 2012 Jared Boone
  * Copyright 2013 Benjamin Vernoux
+ * Copyright 2024 Bernd Herzog
  *
  * This file is part of HackRF.
  *

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -2,6 +2,7 @@
  * Copyright 2012-2022 Great Scott Gadgets <info@greatscottgadgets.com>
  * Copyright 2012 Jared Boone
  * Copyright 2013 Benjamin Vernoux
+ * Copyright 2024 Bernd Herzog
  *
  * This file is part of HackRF.
  *

--- a/firmware/hackrf_usb/usb_api_transceiver.c
+++ b/firmware/hackrf_usb/usb_api_transceiver.c
@@ -27,6 +27,8 @@
 #include "operacake_sctimer.h"
 
 #include <libopencm3/cm3/vector.h>
+#include <libopencm3/cm3/systick.h>
+
 #include "usb_bulk_buffer.h"
 #include "usb_api_m0_state.h"
 
@@ -408,6 +410,15 @@ void transceiver_bulk_transfer_complete(void* user_data, unsigned int bytes_tran
 	m0_state.m4_count += bytes_transferred;
 }
 
+int8_t saturation_buffer = 0;
+uint64_t saturation_buffer_time = 0;
+volatile uint64_t systick_counter = 0;
+
+void sys_tick_handler(void)
+{
+	systick_counter++;
+}
+
 void rx_mode(uint32_t seq)
 {
 	uint32_t usb_count = 0;
@@ -424,7 +435,22 @@ void rx_mode(uint32_t seq)
 				USB_TRANSFER_SIZE,
 				transceiver_bulk_transfer_complete,
 				NULL);
+			
 			usb_count += USB_TRANSFER_SIZE;
+
+			int8_t sample_value = *(int8_t *)&usb_bulk_buffer[usb_count & USB_BULK_BUFFER_MASK];
+			
+			if (sample_value > saturation_buffer)
+				saturation_buffer = sample_value;
+			
+			if (-sample_value > saturation_buffer) 
+				saturation_buffer = -sample_value;
+				
+			if (saturation_buffer_time + 4 < systick_counter) {
+				saturation_buffer_time = systick_counter;
+				hackrf_ui()->set_saturation(saturation_buffer);
+				saturation_buffer = 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request adds a level meter to the hackrf mode.

![level_min](https://github.com/user-attachments/assets/d6e6762d-421c-4163-868a-2548cc0ec19b)

![level_mid](https://github.com/user-attachments/assets/d91bb7ed-0e67-4ab7-b9a0-d20e8597e329)

![level_max](https://github.com/user-attachments/assets/fd486bbd-e8ec-4f50-a15a-7049446ac93f)
