### PR TITLE
Platform detection for Clifford Heath edition

### DIFF
--- a/firmware/common/platform_detect.c
+++ b/firmware/common/platform_detect.c
@@ -225,7 +225,10 @@ void detect_hardware_platform(void)
 		} else if (LOW(adc0_3) && HIGH(adc0_4)) {
 			revision = BOARD_REV_HACKRF1_R7;
 		} else if (LOW(adc0_4)) {
-			revision = revision_from_adc[adc0_3 >> 5];
+			adc0_3 >>= 5;
+			revision = revision_from_adc[adc0_3];
+			if (revision == BOARD_REV_UNRECOGNIZED)	// Return all six bits of the unrecognised value
+				revision = (board_rev_t)((adc0_3 & 0x3F) + BOARD_REV_HACKRF1_ADC_BASE);
 		} else {
 			revision = BOARD_REV_UNRECOGNIZED;
 		}

--- a/firmware/common/platform_detect.h
+++ b/firmware/common/platform_detect.h
@@ -48,6 +48,9 @@ typedef enum {
 	BOARD_REV_HACKRF1_R8 = 3,
 	BOARD_REV_HACKRF1_R9 = 4,
 	BOARD_REV_HACKRF1_R10 = 5,
+	BOARD_REV_HACKRF1_ADC_BASE = 32,
+	// Board revisions having the analog voltage detection but not mapped to a specific hardware revision fit in this range
+	BOARD_REV_HACKRF1_ADC_MAX = 63,
 	BOARD_REV_GSG_HACKRF1_R6 = 0x81,
 	BOARD_REV_GSG_HACKRF1_R7 = 0x82,
 	BOARD_REV_GSG_HACKRF1_R8 = 0x83,


### PR DESCRIPTION
(cherry picked from commit 4e14f9bad027a56c2b1ee611c22c52725b2e3bca)

> When the ADC board_revision value doesn't match an expected value, return all six bits in a special subrange for diagnostics