### PR TITLE
fix compilation warnings

### DIFF
--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -23,7 +23,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-
 #include "usb.h"
 #include "usb_type.h"
 #include "usb_queue.h"
@@ -38,7 +37,6 @@
 #include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/usb.h>
-#include <libopencm3/cm3/sync.h>
 
 usb_device_t* usb_device_usb0 = 0;
 

--- a/firmware/common/usb.h
+++ b/firmware/common/usb.h
@@ -29,8 +29,8 @@
 
 #include "usb_type.h"
 
-void usb_peripheral_reset();
-void usb_phy_enable();
+void usb_peripheral_reset(void);
+void usb_phy_enable(void);
 
 void usb_device_init(const uint_fast8_t device_ordinal, usb_device_t* const device);
 

--- a/firmware/common/usb_queue.c
+++ b/firmware/common/usb_queue.c
@@ -26,6 +26,11 @@
 #include <stddef.h>
 #include <assert.h>
 
+// for __ldrex and __strex declarations
+#ifndef __ARM_ARCH_7M__
+#define __ARM_ARCH_7M__
+#endif
+
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/sync.h>
 


### PR DESCRIPTION
That PR is fixing all the following warnings:

```
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:26:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:45: warning: "NVIC_SGPIO_IRQ" redefined
   45 | #define NVIC_SGPIO_IRQ 31
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:34: note: this is the location of the previous definition
   34 | #define NVIC_SGPIO_IRQ 19
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:50: warning: "NVIC_PIN_INT4_IRQ" redefined
   50 | #define NVIC_PIN_INT4_IRQ 36
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:29: note: this is the location of the previous definition
   29 | #define NVIC_PIN_INT4_IRQ 14
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:55: warning: "NVIC_GINT1_IRQ" redefined
   55 | #define NVIC_GINT1_IRQ 41
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:28: note: this is the location of the previous definition
   28 | #define NVIC_GINT1_IRQ 13
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:56: warning: "NVIC_EVENTROUTER_IRQ" redefined
   56 | #define NVIC_EVENTROUTER_IRQ 42
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:38: note: this is the location of the previous definition
   38 | #define NVIC_EVENTROUTER_IRQ 23
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:59: warning: "NVIC_RTC_IRQ" redefined
   59 | #define NVIC_RTC_IRQ 47
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:16: note: this is the location of the previous definition
   16 | #define NVIC_RTC_IRQ 0
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:61: warning: "NVIC_C_CAN0_IRQ" redefined
   61 | #define NVIC_C_CAN0_IRQ 51
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:44: note: this is the location of the previous definition
   44 | #define NVIC_C_CAN0_IRQ 29
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:64: warning: "NVIC_IRQ_COUNT" redefined
   64 | #define NVIC_IRQ_COUNT 53
      | 
In file included from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/dispatch/nvic.h:30,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/cm3/nvic.h:135,
                 from ~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m4/nvic.h:9,
                 from ~/portapack-mayhem/hackrf/firmware/common/usb.c:32:
~/portapack-mayhem/hackrf/firmware/libopencm3/include/libopencm3/lpc43xx/m0/nvic.h:46: note: this is the location of the previous definition
   46 | #define NVIC_IRQ_COUNT 30
      | 
~/portapack-mayhem/hackrf/firmware/common/usb.c:70:6: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   70 | void usb_peripheral_reset()
      |      ^~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:78:6: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   78 | void usb_phy_enable()
      |      ^~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:92:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   92 | static void usb_clear_all_pending_interrupts()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:125:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  125 | static void usb_flush_all_primed_endpoints()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:318:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  318 | static void usb_controller_run()
      |             ^~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:323:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  323 | static void usb_controller_stop()
      |             ^~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:328:21: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  328 | static uint_fast8_t usb_controller_is_resetting()
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:333:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  333 | static void usb_controller_set_device_mode()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:369:17: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  369 | static uint32_t usb_get_status()
      |                 ^~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:387:17: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  387 | static uint32_t usb_get_endpoint_setup_status()
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:397:17: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  397 | static uint32_t usb_get_endpoint_complete()
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:402:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  402 | static void usb_disable_all_endpoints()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:430:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  430 | static void usb_reset_all_endpoints()
      |             ^~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:437:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  437 | static void usb_controller_reset()
      |             ^~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:565:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  565 | static void usb_check_for_setup_events()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb.c:598:13: warning: function declaration isn't a prototype [-Wstrict-prototypes]
  598 | static void usb_check_for_transfer_events()
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb_queue.c:32:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb_queue.c: In function 'allocate_transfer':
~/portapack-mayhem/hackrf/firmware/common/usb_queue.c:76:22: warning: implicit declaration of function '__ldrex' [-Wimplicit-function-declaration]
   76 |   transfer = (void*) __ldrex((uint32_t*) &queue->free_transfers);
      |                      ^~~~~~~
~/portapack-mayhem/hackrf/firmware/common/usb_queue.c:78:4: warning: implicit declaration of function '__strex' [-Wimplicit-function-declaration]
   78 |    __strex((uint32_t) transfer->next,
      |    ^~~~~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb_request.c:23:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
In file included from ~/portapack-mayhem/hackrf/firmware/common/usb_standard_request.c:28:
~/portapack-mayhem/hackrf/firmware/common/usb.h:32:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   32 | void usb_peripheral_reset();
      | ^~~~
~/portapack-mayhem/hackrf/firmware/common/usb.h:33:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
   33 | void usb_phy_enable();
      | ^~~~
```
