### PR TITLE
Remove unneeded #ifdefs

### DIFF
--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -28,11 +28,6 @@
 #include "usb_queue.h"
 #include "usb_standard_request.h"
 
-// avoid multiple #define declarations
-#ifndef LPC43XX_M4 
-#define LPC43XX_M4
-#endif
-
 #include <libopencm3/lpc43xx/creg.h>
 #include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>

--- a/firmware/common/usb_queue.c
+++ b/firmware/common/usb_queue.c
@@ -26,11 +26,6 @@
 #include <stddef.h>
 #include <assert.h>
 
-// for __ldrex and __strex declarations
-#ifndef __ARM_ARCH_7M__
-#define __ARM_ARCH_7M__
-#endif
-
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/sync.h>
 


### PR DESCRIPTION
We fixed the problems in our CMakeLists so the files are looking the same as the one in original repo (if they accept our warning fix PR)