### PR TITLE
Allow resetting gpio after hw detect

### DIFF
--- a/firmware/common/platform_detect.c
+++ b/firmware/common/platform_detect.c
@@ -303,6 +303,13 @@ void detect_hardware_platform(void)
 	}
 }
 
+void finalize_detect_hardware_platform(void)
+{
+	gpio_output(&gpio2_9_on_P5_0);
+	gpio_output(&gpio3_6_on_P6_10); // known to break cpld init if not reset to output
+	gpio_output(&gpio3_4_on_P6_5);
+}
+
 board_id_t detected_platform(void)
 {
 	return platform;

--- a/firmware/common/platform_detect.h
+++ b/firmware/common/platform_detect.h
@@ -79,5 +79,6 @@ void detect_hardware_platform(void);
 board_id_t detected_platform(void);
 board_rev_t detected_revision(void);
 uint32_t supported_platform(void);
+void finalize_detect_hardware_platform(void);
 
 #endif //__PLATFORM_DETECT_H__


### PR DESCRIPTION
Trying to keep this minimal, but it was much cleaner doing if from here than from the pp codebase..

Added a function in platform_detect.c to revert the gpio pin configuration changes after the detection function finished (it had waaaay too many exit points to handle this inside there, and didn't want to alter the original hackrf mode behaviour either)