### PR TITLE
Add PRALINE-specific board revision detection function

### DIFF
--- a/firmware/common/platform_detect.c
+++ b/firmware/common/platform_detect.c
@@ -303,6 +303,28 @@ void detect_hardware_platform(void)
 	}
 }
 
+/*
+ * PRALINE-specific board revision detection.
+ * Skips the full GPIO pin-probing of detect_hardware_platform() which conflicts
+ * with PRALINE peripheral initialization. Platform is known at compile time;
+ * only the ADC-based revision read and GSG flag check are performed.
+ */
+void detect_praline_board_revision(void)
+{
+	platform = BOARD_ID_PRALINE;
+
+	uint32_t adc0_3 = check_pin_strap(3);
+	revision = praline_revision_from_adc[adc0_3 >> 5];
+
+	/* Check for GSG variant via P4_6 pull-down */
+	scu_pinmux(P4_6, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+	gpio_input(&gpio2_6_on_P4_6);
+	if (gpio_read(&gpio2_6_on_P4_6)) {
+		revision |= BOARD_REV_GSG;
+	}
+	scu_pinmux(P4_6, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+}
+
 void finalize_detect_hardware_platform(void)
 {
 	gpio_output(&gpio2_9_on_P5_0);

--- a/firmware/common/platform_detect.h
+++ b/firmware/common/platform_detect.h
@@ -76,6 +76,7 @@ typedef enum {
 } board_rev_t;
 
 void detect_hardware_platform(void);
+void detect_praline_board_revision(void);
 board_id_t detected_platform(void);
 board_rev_t detected_revision(void);
 uint32_t supported_platform(void);


### PR DESCRIPTION
## Summary
This PR introduces a new `detect_praline_board_revision()` function that provides a streamlined hardware detection path specifically for PRALINE boards.

## Changes
- **New function**: `detect_praline_board_revision()` in `platform_detect.c`
- **API addition**: Function declaration added to `platform_detect.h`

## Motivation
The existing `detect_hardware_platform()` function performs comprehensive GPIO pin-probing that conflicts with PRALINE's peripheral initialization. Since the platform is known at compile time for PRALINE builds, a simplified detection routine is needed.

## Implementation Details
The new function:
1. **Sets platform directly** to `BOARD_ID_PRALINE` (no probing needed)
2. **Reads board revision** via ADC channel 0\_3 using the existing `praline_revision_from_adc` lookup table
3. **Detects GSG variant** by checking for a pull-down on pin P4\_6 (GPIO2\_6)
- Temporarily configures the pin with pull-down enabled
- Sets the `BOARD_REV_GSG` flag if the pin reads high
- Restores pin to no-pull configuration

## Benefits
- Avoids GPIO conflicts with PRALINE peripheral initialization
- Maintains necessary hardware variant detection (revision + GSG flag)
- Provides a cleaner, more efficient detection path for PRALINE-specific builds

## Testing Considerations
- Verify correct revision detection on various PRALINE board revisions
- Confirm GSG variant detection works correctly
- Ensure no peripheral conflicts occur during initialization