### PR TITLE
Remove the redundant explicit #include <libopencm3/lpc43xx/m4/nvic.h>…

### DIFF
--- a/firmware/common/usb.c
+++ b/firmware/common/usb.c
@@ -25,7 +25,6 @@
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/lpc43xx/creg.h>
-#include <libopencm3/lpc43xx/m4/nvic.h>
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/usb.h>
 


### PR DESCRIPTION
Remove the redundant explicit #include <libopencm3/lpc43xx/m4/nvic.h> from usb.c. The <libopencm3/cm3/nvic.h> already dispatches to the correct chip-specific header via the defines. The upstream commit https://github.com/portapack-mayhem/hackrf/commit/b49f1df9562f4872ea3bfa6e1e63fb9b5b49c00e added this explicit include unnecessarily, the dispatch mechanism already handles it.