### PR TITLE
Merge upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,13 +44,22 @@ jobs:
               -DPKG_CONFIG_EXECUTABLE=C:/vcpkg/installed/x64-windows/tools/pkgconf/pkgconf.exe
               -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
               --install-prefix=$env:GITHUB_WORKSPACE/install
+          # windows-latest now ships only Visual Studio 2026, whose CMake
+          # generator ("Visual Studio 18 2026") requires CMake >= 4.2.
+          # Run older CMake versions on windows-2022 (Visual Studio 2022).
+          - sys: {os: 'windows', shell: 'pwsh'}
+            cmake: '3.21.0'
+            runner: 'windows-2022'
+          - sys: {os: 'windows', shell: 'pwsh'}
+            cmake: '4.0.0'
+            runner: 'windows-2022'
           - sys: {os: 'windows', shell: 'msys2'}
             cmake_args: >-
               --install-prefix=/usr/local
 
       # Don't cancel all builds when one fails
       fail-fast: false
-    runs-on: ${{ matrix.sys.os }}-latest
+    runs-on: ${{ matrix.runner || format('{0}-latest', matrix.sys.os) }}
 
     defaults:
       run:

--- a/firmware/blinky/blinky.c
+++ b/firmware/blinky/blinky.c
@@ -45,13 +45,13 @@ int main(void)
 		led_on(LED2);
 		led_on(LED3);
 
-		delay(2000000);
+		delay_ms(150);
 
 		led_off(LED1);
 		led_off(LED2);
 		led_off(LED3);
 
-		delay(2000000);
+		delay_ms(150);
 	}
 
 	return 0;

--- a/firmware/common/clock_gen.c
+++ b/firmware/common/clock_gen.c
@@ -148,7 +148,7 @@ clock_source_t activate_best_clock_source(void)
 			/* Enable PortaPack reference oscillator (if present), and check for valid clock. */
 			if (portapack_reference_oscillator && portapack()) {
 				portapack_reference_oscillator(true);
-				delay(510000); /* loop iterations @ 204MHz for >10ms for oscillator to enable. */
+				delay_ms(18); // for oscillator to enable.
 				if (si5351c_clkin_signal_valid(&si5351c)) {
 					source = CLOCK_SOURCE_PORTAPACK;
 				} else {

--- a/firmware/common/cpld_jtag.c
+++ b/firmware/common/cpld_jtag.c
@@ -22,6 +22,7 @@
 #include "cpld_jtag.h"
 
 #include "platform_detect.h"
+#include "platform_gpio.h"
 #ifdef IS_NOT_PRALINE
 	#include <stdbool.h>
 	#include <stdint.h>
@@ -41,6 +42,28 @@ jtag_gpio_t jtag_gpio_cpld = {};
 jtag_t jtag_cpld = {
 	.gpio = &jtag_gpio_cpld,
 };
+
+void cpld_jtag_pin_setup(void)
+{
+	const platform_gpio_t* gpio = platform_gpio();
+
+	jtag_gpio_cpld.gpio_tck = gpio->cpld_tck;
+
+#ifdef IS_NOT_PRALINE
+	if (IS_NOT_PRALINE) {
+		jtag_gpio_cpld.gpio_tms = gpio->cpld_tms;
+		jtag_gpio_cpld.gpio_tdi = gpio->cpld_tdi;
+		jtag_gpio_cpld.gpio_tdo = gpio->cpld_tdo;
+	}
+#endif
+
+#ifdef IS_EXPANSION_COMPATIBLE
+	if (IS_EXPANSION_COMPATIBLE) {
+		jtag_gpio_cpld.gpio_pp_tms = gpio->cpld_pp_tms;
+		jtag_gpio_cpld.gpio_pp_tdo = gpio->cpld_pp_tdo;
+	}
+#endif
+}
 
 void cpld_jtag_take(jtag_t* const jtag)
 {

--- a/firmware/common/cpld_jtag.h
+++ b/firmware/common/cpld_jtag.h
@@ -45,6 +45,7 @@ typedef struct {
 
 typedef void (*refill_buffer_cb)(void);
 
+void cpld_jtag_pin_setup(void);
 void cpld_jtag_take(jtag_t* const jtag);
 void cpld_jtag_release(jtag_t* const jtag);
 

--- a/firmware/common/cpu_clock.c
+++ b/firmware/common/cpu_clock.c
@@ -33,6 +33,9 @@
 #include "i2c_lpc.h"
 #include "si5351c.h"
 
+/* We start with the CPU clock at 96MHz */
+unsigned int cpu_clock_mhz = 96;
+
 /*
 Configure PLL1 (Main MCU Clock) to max speed (204MHz).
 Note: PLL1 clock is used by M4/M0 core, Peripheral, APB1.
@@ -51,11 +54,14 @@ static void cpu_clock_pll1_max_speed(void)
 	reg_val |= CGU_BASE_M4_CLK_CLK_SEL(CGU_SRC_IRC) | CGU_BASE_M4_CLK_AUTOBLOCK(1);
 	CGU_BASE_M4_CLK = reg_val;
 
+	/* CPU is now at 12MHz */
+	cpu_clock_mhz = 12;
+
 	/* 2. Enable the crystal oscillator. */
 	CGU_XTAL_OSC_CTRL &= ~CGU_XTAL_OSC_CTRL_ENABLE_MASK;
 
 	/* 3. Wait 250us. */
-	delay_us_at_mhz(250, 12);
+	delay_us(250);
 
 	/* 4. Set the AUTOBLOCK bit. */
 	CGU_PLL1_CTRL |= CGU_PLL1_CTRL_AUTOBLOCK(1);
@@ -95,11 +101,17 @@ static void cpu_clock_pll1_max_speed(void)
 	reg_val |= CGU_BASE_M4_CLK_CLK_SEL(CGU_SRC_PLL1);
 	CGU_BASE_M4_CLK = reg_val;
 
+	/* CPU is now at 102MHz */
+	cpu_clock_mhz = 102;
+
 	/* 9. Wait 50us. */
-	delay_us_at_mhz(50, 102);
+	delay_us(50);
 
 	/* 10. Set the PLL1 P-divider to direct output mode (DIRECT=1). */
 	CGU_PLL1_CTRL |= CGU_PLL1_CTRL_DIRECT_MASK;
+
+	/* CPU is now at 204MHz */
+	cpu_clock_mhz = 204;
 }
 
 /* clock startup for LPC4320 configure PLL1 to max speed (204MHz).

--- a/firmware/common/cpu_clock.h
+++ b/firmware/common/cpu_clock.h
@@ -27,6 +27,9 @@ extern "C" {
 
 void cpu_clock_init(void);
 
+// Current clock speed in MHz, updated on clock changes.
+extern unsigned int cpu_clock_mhz;
+
 #ifdef __cplusplus
 }
 #endif

--- a/firmware/common/delay.c
+++ b/firmware/common/delay.c
@@ -21,16 +21,9 @@
 
 #include "delay.h"
 
-void delay(uint32_t duration)
-{
-	uint32_t i;
+#include "cpu_clock.h"
 
-	for (i = 0; i < duration; i++) {
-		__asm__("nop");
-	}
-}
-
-void delay_us_at_mhz(uint32_t us, uint32_t mhz)
+static void delay_us_at_mhz(uint32_t us, uint32_t mhz)
 {
 #if defined(LPC43XX_M4)
 	// The loop below takes 3 cycles per iteration.
@@ -51,4 +44,14 @@ void delay_us_at_mhz(uint32_t us, uint32_t mhz)
 #else
 	#error "No delay loop implementation"
 #endif
+}
+
+void delay_us(uint32_t us)
+{
+	delay_us_at_mhz(us, cpu_clock_mhz);
+}
+
+void delay_ms(uint32_t ms)
+{
+	delay_us_at_mhz(ms * 1000, cpu_clock_mhz);
 }

--- a/firmware/common/delay.h
+++ b/firmware/common/delay.h
@@ -27,8 +27,8 @@ extern "C" {
 
 #include <stdint.h>
 
-void delay(uint32_t duration);
-void delay_us_at_mhz(uint32_t us, uint32_t mhz);
+void delay_us(uint32_t us);
+void delay_ms(uint32_t ms);
 
 #ifdef __cplusplus
 }

--- a/firmware/common/fpga.c
+++ b/firmware/common/fpga.c
@@ -25,7 +25,6 @@
 #include <stdbool.h>
 
 #include "ice40_spi.h"
-#include "max283x.h"
 
 /* Driver instance. */
 fpga_driver_t fpga = {
@@ -57,9 +56,7 @@ void fpga_setup(fpga_driver_t* const drv)
 uint8_t fpga_reg_read(fpga_driver_t* const drv, uint8_t r)
 {
 	uint8_t v;
-	ssp1_set_mode_ice40();
 	v = ice40_spi_read(drv->bus, r);
-	ssp1_set_mode_max283x();
 	drv->regs[r] = v;
 	return v;
 }
@@ -67,9 +64,7 @@ uint8_t fpga_reg_read(fpga_driver_t* const drv, uint8_t r)
 void fpga_reg_write(fpga_driver_t* const drv, uint8_t r, uint8_t v)
 {
 	drv->regs[r] = v;
-	ssp1_set_mode_ice40();
 	ice40_spi_write(drv->bus, r, v);
-	ssp1_set_mode_max283x();
 	FPGA_REG_SET_CLEAN(drv, r);
 }
 

--- a/firmware/common/fpga_image.c
+++ b/firmware/common/fpga_image.c
@@ -26,7 +26,6 @@
 #include "fpga.h"
 #include "ice40_spi.h"
 #include "lz4_blk.h"
-#include "max283x.h"
 #include "selftest.h"
 
 struct fpga_image_read_ctx {
@@ -86,7 +85,6 @@ bool fpga_image_load(struct fpga_loader_t* loader, unsigned int index)
 	// A callback function is used by the FPGA programmer
 	// to obtain consecutive gateware chunks.
 	ice40_spi_target_init(&ice40);
-	ssp1_set_mode_ice40();
 	struct fpga_image_read_ctx fpga_image_ctx = {
 		.loader = loader,
 		.addr = loader->start_addr + bitstream_offset,
@@ -96,7 +94,6 @@ bool fpga_image_load(struct fpga_loader_t* loader, unsigned int index)
 		loader->out_buffer,
 		fpga_image_read_block_cb,
 		&fpga_image_ctx);
-	ssp1_set_mode_max283x();
 
 	// Update selftest result.
 	selftest.fpga_image_load = success ? PASSED : FAILED;

--- a/firmware/common/fpga_image.c
+++ b/firmware/common/fpga_image.c
@@ -133,9 +133,8 @@ static bool fpga_image_load_from_spifi(unsigned int index)
 
 	// Initialize SSP1 for iCE40 programming
 	ice40_spi_target_init(&ice40);
-	ssp1_set_mode_ice40();
 
-	delay_us_at_mhz(2000, 204);
+	delay_us(2000);
 
 	// Calculate start address of bitstream in flash
 	uint32_t bitstream_addr = FPGA_BITSTREAM_FLASH_ADDR + bitstream_offset;
@@ -149,8 +148,6 @@ static bool fpga_image_load_from_spifi(unsigned int index)
 		spifi_out_buffer,
 		fpga_image_read_block_cb_spifi,
 		&fpga_image_ctx);
-
-	ssp1_set_mode_max283x();
 
 	return success;
 }

--- a/firmware/common/fpga_selftest.c
+++ b/firmware/common/fpga_selftest.c
@@ -71,10 +71,8 @@ bool fpga_spi_selftest(void)
 	// Test writing a register and reading it back.
 	uint8_t reg = 6;
 	uint8_t write_value = 0xA5;
-	ssp1_set_mode_ice40();
 	ice40_spi_write(&ice40, reg, write_value);
 	uint8_t read_value = ice40_spi_read(&ice40, reg);
-	ssp1_set_mode_max283x();
 
 	// Update selftest result.
 	selftest.fpga_spi = (read_value == write_value) ? PASSED : FAILED;

--- a/firmware/common/fpga_selftest.c
+++ b/firmware/common/fpga_selftest.c
@@ -200,7 +200,7 @@ bool fpga_if_xcvr_selftest(void)
 
 	// Capture 1: 4 Msps, tone at 0.5 MHz, narrowband filter OFF
 	sample_rate_set(SR_FP_MHZ(4), true);
-	delay_us_at_mhz(1000, 204);
+	delay_ms(1);
 	if (rx_samples(num_samples, 2000000) == -1) {
 		timeout = true;
 	}
@@ -211,7 +211,7 @@ bool fpga_if_xcvr_selftest(void)
 
 	// Capture 2: 4 Msps, tone at 0.5 MHz, narrowband filter ON
 	narrowband_filter_set(1);
-	delay_us_at_mhz(1000, 204);
+	delay_ms(1);
 	if (rx_samples(num_samples, 2000000) == -1) {
 		timeout = true;
 	}
@@ -224,7 +224,7 @@ bool fpga_if_xcvr_selftest(void)
 	fpga_set_tx_nco_pstep(&fpga, 255);
 	sample_rate_set(SR_FP_MHZ(20), true);
 	narrowband_filter_set(0);
-	delay_us_at_mhz(1000, 204);
+	delay_ms(1);
 	if (rx_samples(num_samples, 2000000) == -1) {
 		timeout = true;
 	}
@@ -235,7 +235,7 @@ bool fpga_if_xcvr_selftest(void)
 
 	// Capture 4: 20 Msps, tone at 5 MHz, narrowband filter ON
 	narrowband_filter_set(1);
-	delay_us_at_mhz(1000, 204);
+	delay_ms(1);
 	if (rx_samples(num_samples, 2000000) == -1) {
 		timeout = true;
 	}

--- a/firmware/common/ice40_spi.c
+++ b/firmware/common/ice40_spi.c
@@ -112,14 +112,14 @@ bool ice40_spi_syscfg_program(
 	gpio_clear(drv->gpio_select);
 
 	// Wait a minimum of 200 ns.
-	delay_us_at_mhz(1, 204 / 4); // 250 ns.
+	delay_us(1);
 
 	// Release CRESET_B or drive CRESET_B = 1.
 	gpio_set(drv->gpio_creset);
 
 	// Wait a minimum of 1200 μs to clear internal configuration memory.
 	// Testing showed us that we need to wait longer. Let's wait 1800 μs.
-	delay_us_at_mhz(1800, 204);
+	delay_us(1800);
 
 	// Set SPI_SS = 1, Send 8 dummy clocks.
 	gpio_set(drv->gpio_select);

--- a/firmware/common/ice40_spi.c
+++ b/firmware/common/ice40_spi.c
@@ -40,11 +40,6 @@ ice40_spi_driver_t ice40 = {
 	.bus = &spi_bus_ssp1,
 };
 
-void ssp1_set_mode_ice40(void)
-{
-	spi_bus_start(&spi_bus_ssp1, &ssp_config_ice40_fpga);
-}
-
 void ice40_spi_target_init(ice40_spi_driver_t* const drv)
 {
 	const platform_scu_t* scu = platform_scu();
@@ -67,14 +62,14 @@ void ice40_spi_target_init(ice40_spi_driver_t* const drv)
 uint8_t ice40_spi_read(ice40_spi_driver_t* const drv, uint8_t r)
 {
 	uint8_t value[3] = {r & 0x7F, 0, 0};
-	spi_bus_transfer(drv->bus, value, 3);
+	spi_bus_transfer(drv->bus, &ssp_config_ice40_fpga, value, 3);
 	return value[2];
 }
 
 void ice40_spi_write(ice40_spi_driver_t* const drv, uint8_t r, uint16_t v)
 {
 	uint8_t value[3] = {(r & 0x7F) | 0x80, v, 0};
-	spi_bus_transfer(drv->bus, value, 3);
+	spi_bus_transfer(drv->bus, &ssp_config_ice40_fpga, value, 3);
 }
 
 static void spi_ssp1_wait_for_tx_fifo_not_full(void)
@@ -107,6 +102,8 @@ bool ice40_spi_syscfg_program(
 	size_t (*read_block_cb)(void* ctx),
 	void* read_ctx)
 {
+	spi_bus_start(drv->bus, &ssp_config_ice40_fpga);
+
 	// Drive CRESET_B = 0, SPI_SS = 0, SPI_SCK = 1.
 	gpio_clear(drv->gpio_creset);
 	gpio_clear(drv->gpio_select);

--- a/firmware/common/ice40_spi.c
+++ b/firmware/common/ice40_spi.c
@@ -26,6 +26,7 @@
 #include <libopencm3/lpc43xx/ssp.h>
 
 #include "delay.h"
+#include "platform_gpio.h"
 #include "platform_scu.h"
 
 /* Driver instance. */
@@ -42,7 +43,14 @@ ice40_spi_driver_t ice40 = {
 
 void ice40_spi_target_init(ice40_spi_driver_t* const drv)
 {
+	const platform_gpio_t* gpio = platform_gpio();
 	const platform_scu_t* scu = platform_scu();
+
+	/* Configure drivers and driver pins */
+	ssp_config_ice40_fpga.gpio_select = gpio->fpga_cfg_spi_cs;
+	ice40.gpio_select = gpio->fpga_cfg_spi_cs;
+	ice40.gpio_creset = gpio->fpga_cfg_creset;
+	ice40.gpio_cdone = gpio->fpga_cfg_cdone;
 
 	/* Configure SSP1 Peripheral and relevant FPGA pins. */
 	scu_pinmux(scu->SSP1_CIPO, (SCU_SSP_IO | SCU_CONF_FUNCTION5));

--- a/firmware/common/ice40_spi.h
+++ b/firmware/common/ice40_spi.h
@@ -48,4 +48,3 @@ bool ice40_spi_syscfg_program(
 /* Driver instance. */
 extern ssp_config_t ssp_config_ice40_fpga;
 extern ice40_spi_driver_t ice40;
-void ssp1_set_mode_ice40(void);

--- a/firmware/common/leds.c
+++ b/firmware/common/leds.c
@@ -84,17 +84,17 @@ void set_leds(const uint8_t state)
 	}
 }
 
-void halt_and_flash(const uint32_t duration)
+void halt_and_flash(const uint32_t period_ms)
 {
 	/* blink LED1, LED2, and LED3 */
 	while (1) {
 		led_on(LED1);
 		led_on(LED2);
 		led_on(LED3);
-		delay(duration);
+		delay_ms(period_ms / 2);
 		led_off(LED1);
 		led_off(LED2);
 		led_off(LED3);
-		delay(duration);
+		delay_ms(period_ms / 2);
 	}
 }

--- a/firmware/common/max2831.c
+++ b/firmware/common/max2831.c
@@ -109,7 +109,7 @@ static void max2831_write(max2831_driver_t* const drv, uint8_t r, uint16_t v)
 {
 	uint32_t word = (((uint32_t) v & 0x3fff) << 4) | (r & 0xf);
 	uint16_t values[2] = {word >> 9, word & 0x1ff};
-	spi_bus_transfer(drv->bus, values, 2);
+	spi_bus_transfer(drv->bus, drv->config, values, 2);
 }
 
 uint16_t max2831_reg_read(max2831_driver_t* const drv, uint8_t r)

--- a/firmware/common/max2831.h
+++ b/firmware/common/max2831.h
@@ -50,6 +50,7 @@ typedef enum {
 
 typedef struct _max2831_driver_t {
 	spi_bus_t* bus;
+	void* config;
 	gpio_t gpio_enable;
 	gpio_t gpio_rxtx;
 	gpio_t gpio_rxhp;

--- a/firmware/common/max2837.c
+++ b/firmware/common/max2837.c
@@ -156,14 +156,14 @@ void max2837_setup(max2837_driver_t* const drv)
 static uint16_t max2837_read(max2837_driver_t* const drv, uint8_t r)
 {
 	uint16_t value = (1 << 15) | (r << 10);
-	spi_bus_transfer(drv->bus, &value, 1);
+	spi_bus_transfer(drv->bus, drv->config, &value, 1);
 	return value & 0x3ff;
 }
 
 static void max2837_write(max2837_driver_t* const drv, uint8_t r, uint16_t v)
 {
 	uint16_t value = (r << 10) | (v & 0x3ff);
-	spi_bus_transfer(drv->bus, &value, 1);
+	spi_bus_transfer(drv->bus, drv->config, &value, 1);
 }
 
 uint16_t max2837_reg_read(max2837_driver_t* const drv, uint8_t r)

--- a/firmware/common/max2837.h
+++ b/firmware/common/max2837.h
@@ -43,6 +43,7 @@ typedef enum {
 
 typedef struct _max2837_driver_t {
 	spi_bus_t* bus;
+	void* config;
 	gpio_t gpio_enable;
 	gpio_t gpio_rx_enable;
 	gpio_t gpio_tx_enable;

--- a/firmware/common/max2839.c
+++ b/firmware/common/max2839.c
@@ -164,14 +164,14 @@ void max2839_setup(max2839_driver_t* const drv)
 static uint16_t max2839_read(max2839_driver_t* const drv, uint8_t r)
 {
 	uint16_t value = (1 << 15) | (r << 10);
-	spi_bus_transfer(drv->bus, &value, 1);
+	spi_bus_transfer(drv->bus, drv->config, &value, 1);
 	return value & 0x3ff;
 }
 
 static void max2839_write(max2839_driver_t* const drv, uint8_t r, uint16_t v)
 {
 	uint16_t value = (r << 10) | (v & 0x3ff);
-	spi_bus_transfer(drv->bus, &value, 1);
+	spi_bus_transfer(drv->bus, drv->config, &value, 1);
 }
 
 uint16_t max2839_reg_read(max2839_driver_t* const drv, uint8_t r)

--- a/firmware/common/max2839.h
+++ b/firmware/common/max2839.h
@@ -46,6 +46,7 @@ typedef enum {
 
 typedef struct _max2839_driver_t {
 	spi_bus_t* bus;
+	void* config;
 	gpio_t gpio_enable;
 	gpio_t gpio_rxtx;
 	void (*target_init)(struct _max2839_driver_t* const drv);

--- a/firmware/common/max283x.c
+++ b/firmware/common/max283x.c
@@ -26,6 +26,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include <libopencm3/lpc43xx/ssp.h>
+
 #include "fixed_point.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
@@ -88,8 +90,10 @@ void max283x_setup(max283x_driver_t* const drv)
 	const platform_gpio_t* gpio = platform_gpio();
 
 	/* MAX283x GPIO PinMux */
+	ssp_config_max283x.gpio_select = gpio->max283x_select;
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
+		ssp_config_max283x.data_bits = SSP_DATA_9BITS;
 		drv->type = MAX2831_VARIANT;
 		max2831.gpio_enable = gpio->max283x_enable;
 		max2831.gpio_rxtx = gpio->max283x_rx_enable;
@@ -101,6 +105,7 @@ void max283x_setup(max283x_driver_t* const drv)
 #endif
 #ifdef IS_NOT_PRALINE
 	if (IS_NOT_PRALINE) {
+		ssp_config_max283x.data_bits = SSP_DATA_16BITS;
 	#ifdef IS_H1_R9
 		if (IS_H1_R9) {
 			drv->type = MAX2839_VARIANT;

--- a/firmware/common/max283x.c
+++ b/firmware/common/max283x.c
@@ -29,7 +29,6 @@
 #include "fixed_point.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
-#include "spi_bus.h"
 
 #ifdef IS_PRALINE
 	#include "max2831_target.h"
@@ -56,14 +55,10 @@ ssp_config_t ssp_config_max283x = {
 
 max283x_driver_t max283x = {};
 
-void ssp1_set_mode_max283x(void)
-{
-	spi_bus_start(&spi_bus_ssp1, &ssp_config_max283x);
-}
-
 #ifdef IS_PRALINE
 max2831_driver_t max2831 = {
 	.bus = &spi_bus_ssp1,
+	.config = &ssp_config_max283x,
 	.target_init = max2831_target_init,
 	.set_mode = max2831_target_set_mode,
 };
@@ -72,6 +67,7 @@ max2831_driver_t max2831 = {
 #ifdef IS_NOT_PRALINE
 max2837_driver_t max2837 = {
 	.bus = &spi_bus_ssp1,
+	.config = &ssp_config_max283x,
 	.target_init = max2837_target_init,
 	.set_mode = max2837_target_set_mode,
 };
@@ -80,6 +76,7 @@ max2837_driver_t max2837 = {
 #ifdef IS_HACKRF_ONE
 max2839_driver_t max2839 = {
 	.bus = &spi_bus_ssp1,
+	.config = &ssp_config_max283x,
 	.target_init = max2839_target_init,
 	.set_mode = max2839_target_set_mode,
 };

--- a/firmware/common/max283x.h
+++ b/firmware/common/max283x.h
@@ -143,4 +143,3 @@ void max283x_rx_calibration(max283x_driver_t* const drv);
 /* Driver instance. */
 extern ssp_config_t ssp_config_max283x;
 extern max283x_driver_t max283x;
-void ssp1_set_mode_max283x(void);

--- a/firmware/common/max5864.c
+++ b/firmware/common/max5864.c
@@ -48,14 +48,9 @@ max5864_driver_t max5864 = {
 	.target_init = max5864_target_init,
 };
 
-void ssp1_set_mode_max5864(void)
-{
-	spi_bus_start(max5864.bus, &ssp_config_max5864);
-}
-
 static void max5864_write(max5864_driver_t* const drv, uint8_t value)
 {
-	spi_bus_transfer(drv->bus, &value, 1);
+	spi_bus_transfer(drv->bus, &ssp_config_max5864, &value, 1);
 }
 
 static void max5864_init(max5864_driver_t* const drv)

--- a/firmware/common/max5864.c
+++ b/firmware/common/max5864.c
@@ -27,6 +27,7 @@
 #include <libopencm3/lpc43xx/ssp.h>
 
 #include "max5864_target.h"
+#include "platform_gpio.h"
 #include "spi_bus.h"
 
 /* Driver instance. */
@@ -60,6 +61,8 @@ static void max5864_init(max5864_driver_t* const drv)
 
 void max5864_setup(max5864_driver_t* const drv)
 {
+	ssp_config_max5864.gpio_select = platform_gpio()->max5864_select;
+
 	max5864_init(drv);
 }
 

--- a/firmware/common/max5864.h
+++ b/firmware/common/max5864.h
@@ -42,4 +42,3 @@ void max5864_xcvr(max5864_driver_t* const drv);
 /* Driver instance. */
 extern ssp_config_t ssp_config_max5864;
 extern max5864_driver_t max5864;
-void ssp1_set_mode_max5864(void);

--- a/firmware/common/operacake_sctimer.c
+++ b/firmware/common/operacake_sctimer.c
@@ -75,7 +75,7 @@ void operacake_sctimer_init(void)
 	// there are additional instructions that fill the time. If the duration of
 	// the actions from here to the first access to the SCTimer is changed, then
 	// this delay may need to be increased.
-	delay(8);
+	delay_us(1);
 
 	// Pin definitions for the HackRF
 	// U2CTRL0

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -24,12 +24,10 @@
 #include "pins.h"
 
 #include <libopencm3/lpc43xx/scu.h>
-#include <libopencm3/lpc43xx/ssp.h>
 
 #include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
-#include "max283x.h"
 #include "max5864.h"
 #include "mixer.h"
 #include "platform_detect.h"
@@ -266,18 +264,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	ssp_config_max283x.gpio_select = gpio->max283x_select;
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		ssp_config_max283x.data_bits = SSP_DATA_16BITS;
-	}
-#endif
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		ssp_config_max283x.data_bits = SSP_DATA_9BITS; // send 2 words
-	}
-#endif
-
 	ssp_config_max5864.gpio_select = gpio->max5864_select;
 
 	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -318,8 +318,6 @@ void pins_setup(void)
 	}
 #endif
 
-	ssp1_set_mode_max283x();
-
 	mixer_bus_setup(&mixer);
 
 #ifdef IS_H1_R9

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -28,7 +28,6 @@
 #include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
-#include "mixer.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
 #include "platform_scu.h"
@@ -280,8 +279,6 @@ void pins_setup(void)
 		jtag_gpio_cpld.gpio_pp_tdo = gpio->cpld_pp_tdo;
 	}
 #endif
-
-	mixer_bus_setup(&mixer);
 
 	/* Configure external clock in */
 	scu_pinmux(scu->PINMUX_GP_CLKIN, SCU_CLK_IN | SCU_CONF_FUNCTION1);

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -33,7 +33,6 @@
 #include "power.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
-	#include "ice40_spi.h"
 #endif
 
 void pins_shutdown(void)
@@ -249,16 +248,6 @@ void pins_setup(void)
 #ifdef IS_FOUR_LEDS
 	if (IS_FOUR_LEDS) {
 		gpio_output(gpio->led[3]);
-	}
-#endif
-
-	/* Configure drivers and driver pins */
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		ssp_config_ice40_fpga.gpio_select = gpio->fpga_cfg_spi_cs;
-		ice40.gpio_select = gpio->fpga_cfg_spi_cs;
-		ice40.gpio_creset = gpio->fpga_cfg_creset;
-		ice40.gpio_cdone = gpio->fpga_cfg_cdone;
 	}
 #endif
 

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -35,7 +35,6 @@
 #include "power.h"
 #include "rf_path.h"
 #include "sgpio.h"
-#include "w25q80bv.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
 	#include "ice40_spi.h"
@@ -263,10 +262,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;
-	spi_flash.gpio_hold = gpio->w25q80bv_hold;
-	spi_flash.gpio_wp = gpio->w25q80bv_wp;
-
 	sgpio_config.gpio_q_invert = gpio->q_invert;
 
 #ifdef IS_NOT_PRALINE

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -25,7 +25,6 @@
 
 #include <libopencm3/lpc43xx/scu.h>
 
-#include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
 #include "platform_detect.h"
@@ -260,23 +259,6 @@ void pins_setup(void)
 		ice40.gpio_select = gpio->fpga_cfg_spi_cs;
 		ice40.gpio_creset = gpio->fpga_cfg_creset;
 		ice40.gpio_cdone = gpio->fpga_cfg_cdone;
-	}
-#endif
-
-	jtag_gpio_cpld.gpio_tck = gpio->cpld_tck;
-
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		jtag_gpio_cpld.gpio_tms = gpio->cpld_tms;
-		jtag_gpio_cpld.gpio_tdi = gpio->cpld_tdi;
-		jtag_gpio_cpld.gpio_tdo = gpio->cpld_tdo;
-	}
-#endif
-
-#ifdef IS_EXPANSION_COMPATIBLE
-	if (IS_EXPANSION_COMPATIBLE) {
-		jtag_gpio_cpld.gpio_pp_tms = gpio->cpld_pp_tms;
-		jtag_gpio_cpld.gpio_pp_tdo = gpio->cpld_pp_tdo;
 	}
 #endif
 

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -34,7 +34,6 @@
 #include "platform_scu.h"
 #include "power.h"
 #include "rf_path.h"
-#include "sgpio.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
 	#include "ice40_spi.h"
@@ -228,7 +227,6 @@ void pins_shutdown(void)
 		rf_path_pin_shutdown();
 	}
 #endif
-	sgpio_pin_shutdown(&sgpio_config);
 
 	/* enable input on SCL and SDA pins */
 	SCU_SFSI2C0 = SCU_I2C0_NOMINAL;
@@ -262,14 +260,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	sgpio_config.gpio_q_invert = gpio->q_invert;
-
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		sgpio_config.gpio_trigger_enable = gpio->trigger_enable;
-	}
-#endif
-
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		ssp_config_ice40_fpga.gpio_select = gpio->fpga_cfg_spi_cs;
@@ -297,12 +287,6 @@ void pins_setup(void)
 #endif
 
 	mixer_bus_setup(&mixer);
-
-#ifdef IS_H1_R9
-	if (IS_H1_R9) {
-		sgpio_config.gpio_trigger_enable = gpio->h1r9_trigger_enable;
-	}
-#endif
 
 	// initialize rf_path struct and assign gpio's
 #ifdef IS_HACKRF_ONE
@@ -375,6 +359,4 @@ void pins_setup(void)
 
 	/* Configure external clock in */
 	scu_pinmux(scu->PINMUX_GP_CLKIN, SCU_CLK_IN | SCU_CONF_FUNCTION1);
-
-	sgpio_configure_pin_functions(&sgpio_config);
 }

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -33,7 +33,6 @@
 #include "platform_gpio.h"
 #include "platform_scu.h"
 #include "power.h"
-#include "rf_path.h"
 #ifdef IS_PRALINE
 	#include "clock_io.h"
 	#include "ice40_spi.h"
@@ -204,7 +203,6 @@ void pins_shutdown(void)
 
 		p2_ctrl_set(P2_SIGNAL_CLK3);
 		p1_ctrl_set(P1_SIGNAL_CLKIN);
-		narrowband_filter_set(0);
 		clkin_ctrl_set(CLKIN_SIGNAL_P1);
 
 		gpio_output(gpio->p2_ctrl0);
@@ -214,7 +212,6 @@ void pins_shutdown(void)
 		gpio_output(gpio->p1_ctrl2);
 		gpio_output(gpio->clkin_ctrl);
 		gpio_output(gpio->pps_out);
-		gpio_output(gpio->aa_en);
 		gpio_input(gpio->trigger_in);
 		gpio_input(gpio->trigger_out);
 		gpio_clear(gpio->fpga_cfg_spi_cs);
@@ -223,8 +220,6 @@ void pins_shutdown(void)
 		gpio_output(gpio->fpga_cfg_creset);
 		gpio_input(gpio->fpga_cfg_cdone);
 		gpio_input(gpio->max5864_select);
-
-		rf_path_pin_shutdown();
 	}
 #endif
 
@@ -287,75 +282,6 @@ void pins_setup(void)
 #endif
 
 	mixer_bus_setup(&mixer);
-
-	// initialize rf_path struct and assign gpio's
-#ifdef IS_HACKRF_ONE
-	if (IS_HACKRF_ONE) {
-		rf_path = (rf_path_t){
-			.switchctrl = 0,
-			.gpio_hp = gpio->hp,
-			.gpio_lp = gpio->lp,
-			.gpio_tx_mix_bp = gpio->tx_mix_bp,
-			.gpio_no_mix_bypass = gpio->no_mix_bypass,
-			.gpio_rx_mix_bp = gpio->rx_mix_bp,
-			.gpio_tx_amp = gpio->tx_amp,
-			.gpio_tx = gpio->tx,
-			.gpio_mix_bypass = gpio->mix_bypass,
-			.gpio_rx = gpio->rx,
-			.gpio_no_tx_amp_pwr = gpio->no_tx_amp_pwr,
-			.gpio_amp_bypass = gpio->amp_bypass,
-			.gpio_rx_amp = gpio->rx_amp,
-			.gpio_no_rx_amp_pwr = gpio->no_rx_amp_pwr,
-		};
-	#ifdef IS_H1_R9
-		if (IS_H1_R9) {
-			rf_path.gpio_rx = gpio->h1r9_rx;
-			rf_path.gpio_h1r9_no_ant_pwr = gpio->h1r9_no_ant_pwr;
-		}
-	#endif
-	}
-#endif
-
-#ifdef IS_RAD1O
-	if (IS_RAD1O) {
-		rf_path = (rf_path_t){
-			.switchctrl = 0,
-			.gpio_tx_rx_n = gpio->tx_rx_n,
-			.gpio_tx_rx = gpio->tx_rx,
-			.gpio_by_mix = gpio->by_mix,
-			.gpio_by_mix_n = gpio->by_mix_n,
-			.gpio_by_amp = gpio->by_amp,
-			.gpio_by_amp_n = gpio->by_amp_n,
-			.gpio_mixer_en = gpio->mixer_en,
-			.gpio_low_high_filt = gpio->low_high_filt,
-			.gpio_low_high_filt_n = gpio->low_high_filt_n,
-			.gpio_tx_amp = gpio->tx_amp,
-			.gpio_rx_lna = gpio->rx_lna,
-		};
-	}
-#endif
-
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		rf_path = (rf_path_t){
-			.switchctrl = 0,
-			.gpio_tx_en = gpio->tx_en,
-			.gpio_mix_en_n = gpio->mix_en_n,
-			.gpio_lpf_en = gpio->lpf_en,
-			.gpio_rf_amp_en = gpio->rf_amp_en,
-			.gpio_ant_bias_en_n = gpio->ant_bias_en_n,
-		};
-		if ((detected_revision() == BOARD_REV_PRALINE_R1_0) ||
-		    (detected_revision() == BOARD_REV_GSG_PRALINE_R1_0)) {
-			rf_path.gpio_mix_en_n = gpio->mix_en_n_r1_0;
-		}
-		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PUP | SCU_CONF_FUNCTION4);
-		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-	}
-#endif
-
-	rf_path_pin_setup(&rf_path);
 
 	/* Configure external clock in */
 	scu_pinmux(scu->PINMUX_GP_CLKIN, SCU_CLK_IN | SCU_CONF_FUNCTION1);

--- a/firmware/common/pins.c
+++ b/firmware/common/pins.c
@@ -28,7 +28,6 @@
 #include "cpld_jtag.h"
 #include "gpio.h"
 #include "leds.h"
-#include "max5864.h"
 #include "mixer.h"
 #include "platform_detect.h"
 #include "platform_gpio.h"
@@ -264,8 +263,6 @@ void pins_setup(void)
 #endif
 
 	/* Configure drivers and driver pins */
-	ssp_config_max5864.gpio_select = gpio->max5864_select;
-
 	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;
 	spi_flash.gpio_hold = gpio->w25q80bv_hold;
 	spi_flash.gpio_wp = gpio->w25q80bv_wp;

--- a/firmware/common/platform_detect.c
+++ b/firmware/common/platform_detect.c
@@ -194,11 +194,11 @@ void detect_hardware_platform(void)
 	/* activate internal pull-down */
 	scu_pinmux(P5_0, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
 	scu_pinmux(P6_10, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
-	delay_us_at_mhz(4, 96);
+	delay_us(4);
 	/* tri-state for a moment before testing input */
 	scu_pinmux(P5_0, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
 	scu_pinmux(P6_10, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-	delay_us_at_mhz(4, 96);
+	delay_us(4);
 	/* if input rose quickly, there must be an external pull-up */
 	detected_resistors |= (gpio_read(&gpio2_9_on_P5_0)) ? P5_0_PUP : 0;
 	detected_resistors |= (gpio_read(&gpio3_6_on_P6_10)) ? P6_10_PUP : 0;
@@ -207,12 +207,12 @@ void detect_hardware_platform(void)
 	scu_pinmux(P5_0, SCU_GPIO_PUP | SCU_CONF_FUNCTION0);
 	scu_pinmux(P6_10, SCU_GPIO_PUP | SCU_CONF_FUNCTION0);
 	scu_pinmux(P6_5, SCU_GPIO_PUP | SCU_CONF_FUNCTION0);
-	delay_us_at_mhz(4, 96);
+	delay_us(4);
 	/* tri-state for a moment before testing input */
 	scu_pinmux(P5_0, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
 	scu_pinmux(P6_10, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
 	scu_pinmux(P6_5, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
-	delay_us_at_mhz(4, 96);
+	delay_us(4);
 	/* if input fell quickly, there must be an external pull-down */
 	detected_resistors |= (gpio_read(&gpio2_9_on_P5_0)) ? 0 : P5_0_PDN;
 	detected_resistors |= (gpio_read(&gpio3_6_on_P6_10)) ? 0 : P6_10_PDN;
@@ -221,37 +221,37 @@ void detect_hardware_platform(void)
 	switch (detected_resistors) {
 	case JAWBREAKER_RESISTORS:
 		if (!(supported_platform() & PLATFORM_JAWBREAKER)) {
-			halt_and_flash(3000000);
+			halt_and_flash(500);
 		}
 		platform = BOARD_ID_JAWBREAKER;
 		return;
 	case RAD1O_RESISTORS:
 		if (!(supported_platform() & PLATFORM_RAD1O)) {
-			halt_and_flash(3000000);
+			halt_and_flash(500);
 		}
 		platform = BOARD_ID_RAD1O;
 		return;
 	case HACKRF1_OG_RESISTORS:
 		if (!(supported_platform() & PLATFORM_HACKRF1_OG)) {
-			halt_and_flash(3000000);
+			halt_and_flash(500);
 		}
 		platform = BOARD_ID_HACKRF1_OG;
 		break;
 	case HACKRF1_R9_RESISTORS:
 		if (!(supported_platform() & PLATFORM_HACKRF1_R9)) {
-			halt_and_flash(3000000);
+			halt_and_flash(500);
 		}
 		platform = BOARD_ID_HACKRF1_R9;
 		break;
 	case PRALINE_RESISTORS:
 		if (!(supported_platform() & PLATFORM_PRALINE)) {
-			halt_and_flash(3000000);
+			halt_and_flash(500);
 		}
 		platform = BOARD_ID_PRALINE;
 		break;
 	default:
 		platform = BOARD_ID_UNRECOGNIZED;
-		halt_and_flash(1000000);
+		halt_and_flash(150);
 	}
 
 	uint32_t adc0_3 = check_pin_strap(3);

--- a/firmware/common/portapack.c
+++ b/firmware/common/portapack.c
@@ -31,12 +31,6 @@
 #include "platform_gpio.h"
 #include "platform_scu.h"
 
-static void portapack_sleep_milliseconds(const uint32_t milliseconds)
-{
-	/* NOTE: Naively assumes 204 MHz instruction cycle clock and five instructions per count */
-	delay(milliseconds * 40800);
-}
-
 typedef struct {
 	gpio_t gpio_dir;
 	gpio_t gpio_lcd_rdx;
@@ -244,7 +238,7 @@ static void portapack_lcd_sleep_out(void)
 	// "It will be necessary to wait 120msec after sending Sleep Out
 	// command (when in Sleep In Mode) before Sleep In command can be
 	// sent."
-	portapack_sleep_milliseconds(120);
+	delay_ms(120);
 }
 
 static void portapack_lcd_display_on(void)
@@ -310,11 +304,11 @@ static void portapack_lcd_wake(void)
 static void portapack_lcd_reset(void)
 {
 	portapack_lcd_reset_state(false);
-	portapack_sleep_milliseconds(1);
+	delay_ms(1);
 	portapack_lcd_reset_state(true);
-	portapack_sleep_milliseconds(10);
+	delay_ms(10);
 	portapack_lcd_reset_state(false);
-	portapack_sleep_milliseconds(120);
+	delay_ms(120);
 }
 
 static void portapack_lcd_init(void)

--- a/firmware/common/power.c
+++ b/firmware/common/power.c
@@ -132,7 +132,7 @@ static inline void enable_rf_power_praline(void)
 	gpio_clear(platform_gpio()->vaa_disable);
 
 	/* Let the voltage stabilize */
-	delay(1000000);
+	delay_ms(35);
 }
 
 static inline void disable_rf_power_praline(void)
@@ -147,7 +147,7 @@ static inline void enable_rf_power_rad1o(void)
 	gpio_set(platform_gpio()->vaa_enable);
 
 	/* Let the voltage stabilize */
-	delay(1000000);
+	delay_ms(35);
 }
 
 static inline void disable_rf_power_rad1o(void)

--- a/firmware/common/rad1o/display.c
+++ b/firmware/common/rad1o/display.c
@@ -10,12 +10,6 @@
 #include "gpio_lpc.h"
 #include "delay.h"
 
-static void delayms(const uint32_t milliseconds)
-{
-	/* NOTE: Naively assumes 204 MHz instruction cycle clock and five instructions per count */
-	delay(milliseconds * 40800);
-}
-
 static struct gpio gpio_lcd_cs = GPIO(4, 12);    /* P9_0 */
 static struct gpio gpio_lcd_bl_en = GPIO(0, 8);  /* P1_1 */
 static struct gpio gpio_lcd_reset = GPIO(5, 17); /* P9_4 */
@@ -85,9 +79,9 @@ void rad1o_lcdInit(void)
 
 	// Reset the display
 	gpio_clear(&gpio_lcd_reset);
-	delayms(100);
+	delay_ms(100);
 	gpio_set(&gpio_lcd_reset);
-	delayms(100);
+	delay_ms(100);
 
 	select();
 
@@ -115,7 +109,7 @@ void rad1o_lcdInit(void)
 		  (1 << 12) | (0 << 13) | (0 << 14) | 0);
 
 	write(0, 0x01); /* most color displays need the pause */
-	delayms(10);
+	delay_ms(10);
 
 	size_t i = 0;
 	while (i < sizeof(initseq_d)) {

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -494,11 +494,9 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 
 void rf_path_init(rf_path_t* const rf_path)
 {
-	ssp1_set_mode_max5864();
 	max5864_setup(&max5864);
 	max5864_shutdown(&max5864);
 
-	ssp1_set_mode_max283x();
 	max283x_setup(&max283x);
 	max283x_start(&max283x);
 
@@ -536,9 +534,7 @@ void rf_path_set_direction(rf_path_t* const rf_path, const rf_path_direction_t d
 		} else {
 			mixer_enable(&mixer);
 		}
-		ssp1_set_mode_max5864();
 		max5864_tx(&max5864);
-		ssp1_set_mode_max283x();
 		max283x_tx(&max283x);
 		break;
 
@@ -553,9 +549,7 @@ void rf_path_set_direction(rf_path_t* const rf_path, const rf_path_direction_t d
 		} else {
 			mixer_enable(&mixer);
 		}
-		ssp1_set_mode_max5864();
 		max5864_rx(&max5864);
-		ssp1_set_mode_max283x();
 		max283x_rx(&max283x);
 		break;
 
@@ -564,9 +558,7 @@ void rf_path_set_direction(rf_path_t* const rf_path, const rf_path_direction_t d
 	case RF_PATH_DIRECTION_RX_CALIBRATION:
 		rf_path->switchctrl &= ~SWITCHCTRL_TX;
 		mixer_disable(&mixer);
-		ssp1_set_mode_max5864();
 		max5864_xcvr(&max5864);
-		ssp1_set_mode_max283x();
 		if (direction == RF_PATH_DIRECTION_TX_CALIBRATION) {
 			max283x_tx_calibration(&max283x);
 		} else {
@@ -581,9 +573,7 @@ void rf_path_set_direction(rf_path_t* const rf_path, const rf_path_direction_t d
 		/* Set RF path to receive direction when "off" */
 		rf_path->switchctrl &= ~SWITCHCTRL_TX;
 		mixer_disable(&mixer);
-		ssp1_set_mode_max5864();
 		max5864_standby(&max5864);
-		ssp1_set_mode_max283x();
 		max283x_set_mode(&max283x, MAX283x_MODE_STANDBY);
 		break;
 	}

--- a/firmware/common/rf_path.c
+++ b/firmware/common/rf_path.c
@@ -30,8 +30,6 @@
 #ifdef IS_NOT_JAWBREAKER
 	#include <libopencm3/lpc43xx/scu.h>
 	#include "platform_scu.h"
-#endif
-#ifdef IS_PRALINE
 	#include "platform_gpio.h"
 #endif
 
@@ -344,6 +342,10 @@ void rf_path_pin_shutdown(void)
 
 		/* Configure RF power supply (VAA) switch */
 		scu_pinmux(scu->NO_VAA_ENABLE, SCU_GPIO_PDN | SCU_CONF_FUNCTION0);
+
+		/* Disable narrowband filter. */
+		narrowband_filter_set(0);
+		gpio_output(platform_gpio()->aa_en);
 	}
 #endif
 }
@@ -353,7 +355,75 @@ void rf_path_pin_setup(rf_path_t* const rf_path)
 #ifdef IS_JAWBREAKER
 	(void) rf_path;
 #else
+	const platform_gpio_t* gpio = platform_gpio();
 	const platform_scu_t* scu = platform_scu();
+#endif
+
+	// initialize rf_path struct and assign gpio's
+#ifdef IS_HACKRF_ONE
+	if (IS_HACKRF_ONE) {
+		*rf_path = (rf_path_t){
+			.switchctrl = 0,
+			.gpio_hp = gpio->hp,
+			.gpio_lp = gpio->lp,
+			.gpio_tx_mix_bp = gpio->tx_mix_bp,
+			.gpio_no_mix_bypass = gpio->no_mix_bypass,
+			.gpio_rx_mix_bp = gpio->rx_mix_bp,
+			.gpio_tx_amp = gpio->tx_amp,
+			.gpio_tx = gpio->tx,
+			.gpio_mix_bypass = gpio->mix_bypass,
+			.gpio_rx = gpio->rx,
+			.gpio_no_tx_amp_pwr = gpio->no_tx_amp_pwr,
+			.gpio_amp_bypass = gpio->amp_bypass,
+			.gpio_rx_amp = gpio->rx_amp,
+			.gpio_no_rx_amp_pwr = gpio->no_rx_amp_pwr,
+		};
+	#ifdef IS_H1_R9
+		if (IS_H1_R9) {
+			rf_path->gpio_rx = gpio->h1r9_rx;
+			rf_path->gpio_h1r9_no_ant_pwr = gpio->h1r9_no_ant_pwr;
+		}
+	#endif
+	}
+#endif
+
+#ifdef IS_RAD1O
+	if (IS_RAD1O) {
+		*rf_path = (rf_path_t){
+			.switchctrl = 0,
+			.gpio_tx_rx_n = gpio->tx_rx_n,
+			.gpio_tx_rx = gpio->tx_rx,
+			.gpio_by_mix = gpio->by_mix,
+			.gpio_by_mix_n = gpio->by_mix_n,
+			.gpio_by_amp = gpio->by_amp,
+			.gpio_by_amp_n = gpio->by_amp_n,
+			.gpio_mixer_en = gpio->mixer_en,
+			.gpio_low_high_filt = gpio->low_high_filt,
+			.gpio_low_high_filt_n = gpio->low_high_filt_n,
+			.gpio_tx_amp = gpio->tx_amp,
+			.gpio_rx_lna = gpio->rx_lna,
+		};
+	}
+#endif
+
+#ifdef IS_PRALINE
+	if (IS_PRALINE) {
+		*rf_path = (rf_path_t){
+			.switchctrl = 0,
+			.gpio_tx_en = gpio->tx_en,
+			.gpio_mix_en_n = gpio->mix_en_n,
+			.gpio_lpf_en = gpio->lpf_en,
+			.gpio_rf_amp_en = gpio->rf_amp_en,
+			.gpio_ant_bias_en_n = gpio->ant_bias_en_n,
+		};
+		if ((detected_revision() == BOARD_REV_PRALINE_R1_0) ||
+		    (detected_revision() == BOARD_REV_GSG_PRALINE_R1_0)) {
+			rf_path->gpio_mix_en_n = gpio->mix_en_n_r1_0;
+		}
+		scu_pinmux(scu->PINMUX_FPGA_CRESET, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+		scu_pinmux(scu->PINMUX_FPGA_CDONE, SCU_GPIO_PUP | SCU_CONF_FUNCTION4);
+		scu_pinmux(scu->PINMUX_FPGA_SPI_CS, SCU_GPIO_NOPULL | SCU_CONF_FUNCTION0);
+	}
 #endif
 
 #ifdef IS_HACKRF_ONE

--- a/firmware/common/rffc5071.c
+++ b/firmware/common/rffc5071.c
@@ -163,13 +163,13 @@ void rffc5071_lock_test(rffc5071_driver_t* const drv)
 		rffc5071_enable(drv);
 
 		// Wait 1ms.
-		delay_us_at_mhz(1000, 204);
+		delay_ms(1);
 
 		// Check for lock.
 		lock = rffc5071_check_lock(drv);
 
 		rffc5071_disable(drv);
-		delay_us_at_mhz(100, 204);
+		delay_us(100);
 
 		selftest.mixer_locks[i] = lock;
 	}

--- a/firmware/common/rffc5071.c
+++ b/firmware/common/rffc5071.c
@@ -202,7 +202,7 @@ static uint16_t rffc5071_spi_read(rffc5071_driver_t* const drv, uint8_t r)
 	(void) drv;
 
 	uint16_t data[] = {0x80 | (r & 0x7f), 0xffff};
-	spi_bus_transfer(drv->bus, data, 2);
+	spi_bus_transfer(drv->bus, drv->bus->config, data, 2);
 	return data[1];
 }
 
@@ -211,7 +211,7 @@ static void rffc5071_spi_write(rffc5071_driver_t* const drv, uint8_t r, uint16_t
 	(void) drv;
 
 	uint16_t data[] = {0x00 | (r & 0x7f), v};
-	spi_bus_transfer(drv->bus, data, 2);
+	spi_bus_transfer(drv->bus, drv->bus->config, data, 2);
 }
 
 uint16_t rffc5071_reg_read(rffc5071_driver_t* const drv, uint8_t r)

--- a/firmware/common/rom_iap.c
+++ b/firmware/common/rom_iap.c
@@ -23,7 +23,6 @@
 #include <stdint.h>
 
 #include "rom_iap.h"
-#include "spi_bus.h"
 #include "w25q80bv.h"
 
 #define ROM_IAP_ADDR       (0x10400100)
@@ -77,7 +76,6 @@ isp_iap_ret_code_t iap_cmd_call(iap_cmd_res_t* iap_cmd_res)
 		  Alternative way to retrieve Part Id on MCU with no IAP 
 		  Read Serial No => Read Unique ID in SPIFI (only compatible with W25Q80BV
 		*/
-		spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 		w25q80bv_setup(&spi_flash);
 
 		switch (iap_cmd_res->cmd_param.command_code) {

--- a/firmware/common/sgpio.c
+++ b/firmware/common/sgpio.c
@@ -29,6 +29,7 @@
 #include <libopencm3/lpc43xx/sgpio.h>
 
 #include "platform_detect.h"
+#include "platform_gpio.h"
 #include "platform_scu.h"
 #include "sgpio.h"
 #ifdef IS_NOT_PRALINE
@@ -91,7 +92,22 @@ void sgpio_pin_shutdown(sgpio_config_t* const config)
 
 void sgpio_configure_pin_functions(sgpio_config_t* const config)
 {
+	const platform_gpio_t* gpio = platform_gpio();
 	const platform_scu_t* scu = platform_scu();
+
+	config->gpio_q_invert = gpio->q_invert;
+
+#ifdef IS_NOT_PRALINE
+	if (IS_NOT_PRALINE) {
+		config->gpio_trigger_enable = gpio->trigger_enable;
+	}
+#endif
+
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		config->gpio_trigger_enable = gpio->h1r9_trigger_enable;
+	}
+#endif
 
 	scu_pinmux(scu->PINMUX_SGPIO0, scu->PINMUX_SGPIO0_PINCFG);
 	scu_pinmux(scu->PINMUX_SGPIO1, scu->PINMUX_SGPIO1_PINCFG);

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -51,12 +51,6 @@ si5351c_driver_t si5351c = {
 	.i2c_address = 0x60,
 };
 
-uint8_t clkout_id;
-uint8_t mcu_clkin_id;
-
-static bool input_initialized = false;
-static si5351c_input_t active_input;
-
 /* write to single register */
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val)
 {
@@ -290,7 +284,7 @@ void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		const platform_gpio_t* gpio = platform_gpio();
-		if (drv->clk[clkout_id].output_enable) {
+		if (drv->clk[drv->clkout_id].output_enable) {
 			gpio_set(gpio->h1r9_clkout_en);
 		} else {
 			gpio_clear(gpio->h1r9_clkout_en);
@@ -310,7 +304,7 @@ void si5351c_set_int_mode(
 
 void si5351c_change_input(si5351c_driver_t* const drv, si5351c_input_t input)
 {
-	if (input_initialized && input == active_input) {
+	if (drv->input_initialized && input == drv->active_input) {
 		return;
 	}
 	si5351c_disable_all_outputs(drv);
@@ -334,8 +328,8 @@ void si5351c_change_input(si5351c_driver_t* const drv, si5351c_input_t input)
 	}
 #endif
 	si5351c_configure_pll_multisynth(drv, input);
-	active_input = input;
-	input_initialized = true;
+	drv->active_input = input;
+	drv->input_initialized = true;
 	si5351c_reset_plls(drv, SI5351C_PLL_MASK_BOTH);
 }
 
@@ -353,11 +347,11 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	drv->clk[clkout_id].output_enable = enable;
-	drv->clk[clkout_id].power_down = !enable;
+	drv->clk[drv->clkout_id].output_enable = enable;
+	drv->clk[drv->clkout_id].power_down = !enable;
 
 	/* Configure clock to 10MHz */
-	si5351c_configure_multisynth(drv, clkout_id, 80 * 128 - 512, 0, 1, 0);
+	si5351c_configure_multisynth(drv, drv->clkout_id, 80 * 128 - 512, 0, 1, 0);
 
 	si5351c_configure_clock_control(drv);
 	si5351c_enable_clock_outputs(drv);
@@ -373,18 +367,18 @@ void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
 #endif
 #ifdef IS_NOT_H1_R9
 	if (IS_NOT_H1_R9) {
-		drv->clk[mcu_clkin_id].output_enable = enable;
-		drv->clk[mcu_clkin_id].power_down = !enable;
+		drv->clk[drv->mcu_clkin_id].output_enable = enable;
+		drv->clk[drv->mcu_clkin_id].power_down = !enable;
 
 		/* Configure clock to 40MHz */
-		if (mcu_clkin_id >= 6) {
+		if (drv->mcu_clkin_id >= 6) {
 			// MCU_CLKIN on CLK6 or CLK7, integer only MS.
-			si5351c_configure_multisynth(drv, mcu_clkin_id, 20, 0, 0, 0);
+			si5351c_configure_multisynth(drv, drv->mcu_clkin_id, 20, 0, 0, 0);
 		} else {
 			// MCU_CLKIN on CLK0 to CLK5, fractional-capable MS.
 			si5351c_configure_multisynth(
 				drv,
-				mcu_clkin_id,
+				drv->mcu_clkin_id,
 				20 * 128 - 512,
 				0,
 				1,
@@ -509,7 +503,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 	};
 	/* CLK3: CLKOUT */
 	drv->clk[3] = clkout;
-	clkout_id = 3;
+	drv->clkout_id = 3;
 	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
 	drv->clk[4] = (si5351c_clk_t){
 		.output_enable = true,
@@ -531,7 +525,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 	drv->clk[6] = powered_down;
 	/* CLK7: LPC43xx */
 	drv->clk[7] = mcu_clkin;
-	mcu_clkin_id = 7;
+	drv->mcu_clkin_id = 7;
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
@@ -553,8 +547,8 @@ void si5351c_init(si5351c_driver_t* const drv)
 		};
 		/* CLK2: CLKOUT/LPC4320 */
 		drv->clk[2] = clkout;
-		clkout_id = 2;
-		mcu_clkin_id = 2;
+		drv->clkout_id = 2;
+		drv->mcu_clkin_id = 2;
 		/* Other outputs not present on Si5351A */
 		drv->clk[3] = powered_down;
 		drv->clk[4] = powered_down;
@@ -584,7 +578,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		/* CLK3: CLKOUT */
 		clkout.pll = SI5351C_PLL_B;
 		drv->clk[3] = clkout;
-		clkout_id = 3;
+		drv->clkout_id = 3;
 		/* CLK4: XCVR_CLK */
 		drv->clk[4] = (si5351c_clk_t){
 			.output_enable = true,
@@ -614,7 +608,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		} else {
 			/* CLK2: MCU_CLK */
 			drv->clk[2] = mcu_clkin;
-			mcu_clkin_id = 2;
+			drv->mcu_clkin_id = 2;
 		}
 	}
 #endif

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -51,8 +51,6 @@ si5351c_driver_t si5351c = {
 	.i2c_address = 0x60,
 };
 
-si5351c_clk_t clk[8];
-
 uint8_t clkout_id;
 uint8_t mcu_clkin_id;
 
@@ -267,12 +265,12 @@ void si5351c_configure_multisynth(
 void si5351c_configure_clock_control(si5351c_driver_t* const drv)
 {
 	for (int i = 0; i < 8; i++) {
-		set_CLK_PDN(drv, i, clk[i].power_down);
-		set_MS_INT(drv, i, clk[i].mode);
-		set_MS_SRC(drv, i, clk[i].pll);
-		set_CLK_SRC(drv, i, clk[i].source);
-		set_CLK_IDRV(drv, i, clk[i].drive);
-		set_CLK_INV(drv, i, clk[i].invert);
+		set_CLK_PDN(drv, i, drv->clk[i].power_down);
+		set_MS_INT(drv, i, drv->clk[i].mode);
+		set_MS_SRC(drv, i, drv->clk[i].pll);
+		set_CLK_SRC(drv, i, drv->clk[i].source);
+		set_CLK_IDRV(drv, i, drv->clk[i].drive);
+		set_CLK_INV(drv, i, drv->clk[i].invert);
 	}
 
 	si5351c_regs_commit(drv);
@@ -284,15 +282,15 @@ void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 		set_CLK_OEB(
 			drv,
 			i,
-			clk[i].output_enable ? SI5351C_OUTPUT_ENABLE :
-					       SI5351C_OUTPUT_DISABLE);
+			drv->clk[i].output_enable ? SI5351C_OUTPUT_ENABLE :
+						    SI5351C_OUTPUT_DISABLE);
 	}
 	si5351c_regs_commit(drv);
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		const platform_gpio_t* gpio = platform_gpio();
-		if (clk[clkout_id].output_enable) {
+		if (drv->clk[clkout_id].output_enable) {
 			gpio_set(gpio->h1r9_clkout_en);
 		} else {
 			gpio_clear(gpio->h1r9_clkout_en);
@@ -355,8 +353,8 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	clk[clkout_id].output_enable = enable;
-	clk[clkout_id].power_down = !enable;
+	drv->clk[clkout_id].output_enable = enable;
+	drv->clk[clkout_id].power_down = !enable;
 
 	/* Configure clock to 10MHz */
 	si5351c_configure_multisynth(drv, clkout_id, 80 * 128 - 512, 0, 1, 0);
@@ -375,8 +373,8 @@ void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
 #endif
 #ifdef IS_NOT_H1_R9
 	if (IS_NOT_H1_R9) {
-		clk[mcu_clkin_id].output_enable = enable;
-		clk[mcu_clkin_id].power_down = !enable;
+		drv->clk[mcu_clkin_id].output_enable = enable;
+		drv->clk[mcu_clkin_id].power_down = !enable;
 
 		/* Configure clock to 40MHz */
 		if (mcu_clkin_id >= 6) {
@@ -485,7 +483,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 	};
 
 	/* CLK0: MAX5864/CPLD */
-	clk[0] = (si5351c_clk_t){
+	drv->clk[0] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_FRAC,
 		.pll = SI5351C_PLL_A,
@@ -493,7 +491,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_8MA,
 	};
 	/* CLK1: CPLD */
-	clk[1] = (si5351c_clk_t){
+	drv->clk[1] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -502,7 +500,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.invert = true,
 	};
 	/* CLK2: SGPIO */
-	clk[2] = (si5351c_clk_t){
+	drv->clk[2] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -510,10 +508,10 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_2MA,
 	};
 	/* CLK3: CLKOUT */
-	clk[3] = clkout;
+	drv->clk[3] = clkout;
 	clkout_id = 3;
 	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
-	clk[4] = (si5351c_clk_t){
+	drv->clk[4] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -522,7 +520,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.invert = true,
 	};
 	/* CLK5: MAX2837 (MAX2871 on rad1o) */
-	clk[5] = (si5351c_clk_t){
+	drv->clk[5] = (si5351c_clk_t){
 		.output_enable = true,
 		.mode = SI5351C_MODE_INT,
 		.pll = SI5351C_PLL_A,
@@ -530,15 +528,15 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_4MA,
 	};
 	/* CLK6: none */
-	clk[6] = powered_down;
+	drv->clk[6] = powered_down;
 	/* CLK7: LPC43xx */
-	clk[7] = mcu_clkin;
+	drv->clk[7] = mcu_clkin;
 	mcu_clkin_id = 7;
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		/* CLK0: MAX5864/CPLD/SGPIO (sample clocks) */
-		clk[0] = (si5351c_clk_t){
+		drv->clk[0] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_INT,
 			.pll = SI5351C_PLL_A,
@@ -546,7 +544,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.drive = SI5351C_DRIVE_6MA,
 		};
 		/* CLK1: RFFC5072/MAX2839 */
-		clk[1] = (si5351c_clk_t){
+		drv->clk[1] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_FRAC,
 			.pll = SI5351C_PLL_A,
@@ -554,21 +552,21 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.drive = SI5351C_DRIVE_4MA,
 		};
 		/* CLK2: CLKOUT/LPC4320 */
-		clk[2] = clkout;
+		drv->clk[2] = clkout;
 		clkout_id = 2;
 		mcu_clkin_id = 2;
 		/* Other outputs not present on Si5351A */
-		clk[3] = powered_down;
-		clk[4] = powered_down;
-		clk[5] = powered_down;
-		clk[6] = powered_down;
-		clk[7] = powered_down;
+		drv->clk[3] = powered_down;
+		drv->clk[4] = powered_down;
+		drv->clk[5] = powered_down;
+		drv->clk[6] = powered_down;
+		drv->clk[7] = powered_down;
 	}
 #endif
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		/* CLK0: AFE_CLK */
-		clk[0] = (si5351c_clk_t){
+		drv->clk[0] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_FRAC,
 			.pll = SI5351C_PLL_A,
@@ -576,7 +574,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.drive = SI5351C_DRIVE_4MA,
 		};
 		/* CLK1: SCT_CLK and FPGA_CLK */
-		clk[1] = (si5351c_clk_t){
+		drv->clk[1] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_FRAC,
 			.pll = SI5351C_PLL_A,
@@ -585,10 +583,10 @@ void si5351c_init(si5351c_driver_t* const drv)
 		};
 		/* CLK3: CLKOUT */
 		clkout.pll = SI5351C_PLL_B;
-		clk[3] = clkout;
+		drv->clk[3] = clkout;
 		clkout_id = 3;
 		/* CLK4: XCVR_CLK */
-		clk[4] = (si5351c_clk_t){
+		drv->clk[4] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_INT,
 			.pll = SI5351C_PLL_B,
@@ -597,7 +595,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			.invert = true,
 		};
 		/* CLK5: MIX_CLK */
-		clk[5] = (si5351c_clk_t){
+		drv->clk[5] = (si5351c_clk_t){
 			.output_enable = true,
 			.mode = SI5351C_MODE_INT,
 			.pll = SI5351C_PLL_B,
@@ -606,7 +604,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		};
 		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
 			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
-			clk[2] = (si5351c_clk_t){
+			drv->clk[2] = (si5351c_clk_t){
 				.output_enable = true,
 				.mode = SI5351C_MODE_FRAC,
 				.pll = SI5351C_PLL_A,
@@ -615,7 +613,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 			};
 		} else {
 			/* CLK2: MCU_CLK */
-			clk[2] = mcu_clkin;
+			drv->clk[2] = mcu_clkin;
 			mcu_clkin_id = 2;
 		}
 	}

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -224,7 +224,7 @@ void si5351c_reset_plls(si5351c_driver_t* const drv, si5351c_pll_mask_t mask)
 	set_PLLA_RST(drv, (mask & SI5351C_PLL_MASK_A) ? true : false);
 	set_PLLB_RST(drv, (mask & SI5351C_PLL_MASK_B) ? true : false);
 	si5351c_regs_commit(drv);
-	delay_us_at_mhz(2000, 204);
+	delay_ms(2);
 	si5351c_enable_clock_outputs(drv);
 }
 

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -54,6 +54,7 @@ si5351c_driver_t si5351c = {
 si5351c_clk_t clk[8];
 
 uint8_t clkout_id;
+uint8_t mcu_clkin_id;
 
 static bool input_initialized = false;
 static si5351c_input_t active_input;
@@ -364,6 +365,40 @@ void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 	si5351c_enable_clock_outputs(drv);
 }
 
+void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable)
+{
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		/* MCU clock is shared with CLKOUT. */
+		si5351c_clkout_enable(drv, enable);
+	}
+#endif
+#ifdef IS_NOT_H1_R9
+	if (IS_NOT_H1_R9) {
+		clk[mcu_clkin_id].output_enable = enable;
+		clk[mcu_clkin_id].power_down = !enable;
+
+		/* Configure clock to 40MHz */
+		if (mcu_clkin_id >= 6) {
+			// MCU_CLKIN on CLK6 or CLK7, integer only MS.
+			si5351c_configure_multisynth(drv, mcu_clkin_id, 20, 0, 0, 0);
+		} else {
+			// MCU_CLKIN on CLK0 to CLK5, fractional-capable MS.
+			si5351c_configure_multisynth(
+				drv,
+				mcu_clkin_id,
+				20 * 128 - 512,
+				0,
+				1,
+				0);
+		}
+
+		si5351c_configure_clock_control(drv);
+		si5351c_enable_clock_outputs(drv);
+	}
+#endif
+}
+
 void si5351c_init(si5351c_driver_t* const drv)
 {
 	/* Read revision ID */
@@ -434,6 +469,15 @@ void si5351c_init(si5351c_driver_t* const drv)
 		.drive = SI5351C_DRIVE_8MA,
 	};
 
+	si5351c_clk_t mcu_clkin = {
+		.output_enable = false,
+		.power_down = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_2MA,
+	};
+
 	si5351c_clk_t powered_down = {
 		.output_enable = false,
 		.power_down = true,
@@ -488,7 +532,8 @@ void si5351c_init(si5351c_driver_t* const drv)
 	/* CLK6: none */
 	clk[6] = powered_down;
 	/* CLK7: LPC43xx */
-	clk[7] = powered_down;
+	clk[7] = mcu_clkin;
+	mcu_clkin_id = 7;
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
@@ -511,6 +556,7 @@ void si5351c_init(si5351c_driver_t* const drv)
 		/* CLK2: CLKOUT/LPC4320 */
 		clk[2] = clkout;
 		clkout_id = 2;
+		mcu_clkin_id = 2;
 		/* Other outputs not present on Si5351A */
 		clk[3] = powered_down;
 		clk[4] = powered_down;
@@ -569,7 +615,8 @@ void si5351c_init(si5351c_driver_t* const drv)
 			};
 		} else {
 			/* CLK2: MCU_CLK */
-			clk[2] = powered_down;
+			clk[2] = mcu_clkin;
+			mcu_clkin_id = 2;
 		}
 	}
 #endif

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -583,6 +583,11 @@ void si5351c_init(si5351c_driver_t* const drv)
 		selftest.report.pass = false;
 	}
 
+	/* Wait for on-chip initialization to complete. */
+	while (get_SYS_INIT(drv)) {
+		si5351c_read_single(drv, SYS_INIT);
+	}
+
 	/* Cache all current register values. */
 	uint8_t data_tx[] = {0};
 	i2c_bus_transfer(

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -543,9 +543,9 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 	}
 }
 
-void si5351c_clkout_enable(si5351c_driver_t* const drv, uint8_t enable)
+void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	clkout_enabled = (enable > 0);
+	clkout_enabled = enable;
 
 	uint8_t clkout = 3;
 

--- a/firmware/common/si5351c.c
+++ b/firmware/common/si5351c.c
@@ -51,10 +51,12 @@ si5351c_driver_t si5351c = {
 	.i2c_address = 0x60,
 };
 
+si5351c_clk_t clk[8];
+
+uint8_t clkout_id;
+
 static bool input_initialized = false;
 static si5351c_input_t active_input;
-/* External clock output default is deactivated as it creates noise */
-static bool clkout_enabled = false;
 
 /* write to single register */
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val)
@@ -263,146 +265,6 @@ void si5351c_configure_multisynth(
 
 void si5351c_configure_clock_control(si5351c_driver_t* const drv)
 {
-	si5351c_clk_ctrl_t clkout = {
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_8MA,
-	};
-
-	si5351c_clk_ctrl_t powered_down = {
-		.power_down = true,
-		.mode = SI5351C_MODE_INT,
-	};
-
-	if (!clkout_enabled) {
-		clkout = powered_down;
-	}
-
-	si5351c_clk_ctrl_t clk[8];
-
-	/* Clock to CPU is deactivated as it is not used and creates noise */
-	/* External clock output is kept in current state */
-
-	/* CLK0: MAX5864/CPLD */
-	clk[0] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_FRAC,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_8MA,
-	};
-	/* CLK1: CPLD */
-	clk[1] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_0_4,
-		.drive = SI5351C_DRIVE_2MA,
-		.invert = true,
-	};
-	/* CLK2: SGPIO */
-	clk[2] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_0_4,
-		.drive = SI5351C_DRIVE_2MA,
-	};
-	/* CLK3: CLKOUT */
-	clk[3] = clkout;
-	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
-	clk[4] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_6MA,
-		.invert = true,
-	};
-	/* CLK5: MAX2837 (MAX2871 on rad1o) */
-	clk[5] = (si5351c_clk_ctrl_t){
-		.mode = SI5351C_MODE_INT,
-		.pll = SI5351C_PLL_A,
-		.source = SI5351C_SRC_MULTISYNTH_SELF,
-		.drive = SI5351C_DRIVE_4MA,
-	};
-	/* CLK6: none */
-	clk[6] = powered_down;
-	/* CLK7: LPC43xx */
-	clk[7] = powered_down;
-
-#ifdef IS_H1_R9
-	if (IS_H1_R9) {
-		/* CLK0: MAX5864/CPLD/SGPIO (sample clocks) */
-		clk[0] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_INT,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_6MA,
-		};
-		/* CLK1: RFFC5072/MAX2839 */
-		clk[1] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_FRAC,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-		};
-		/* CLK2: CLKOUT/LPC4320 */
-		clk[2] = clkout;
-		/* Other outputs not present on Si5351A */
-		clk[3] = powered_down;
-		clk[4] = powered_down;
-		clk[5] = powered_down;
-		clk[6] = powered_down;
-		clk[7] = powered_down;
-	}
-#endif
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		/* CLK0: AFE_CLK */
-		clk[0] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_FRAC,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-		};
-		/* CLK1: SCT_CLK and FPGA_CLK */
-		clk[1] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_FRAC,
-			.pll = SI5351C_PLL_A,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_2MA,
-		};
-		/* CLK3: CLKOUT */
-		clkout.pll = SI5351C_PLL_B;
-		clk[3] = clkout;
-		/* CLK4: XCVR_CLK */
-		clk[4] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_INT,
-			.pll = SI5351C_PLL_B,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-			.invert = true,
-		};
-		/* CLK5: MIX_CLK */
-		clk[5] = (si5351c_clk_ctrl_t){
-			.mode = SI5351C_MODE_INT,
-			.pll = SI5351C_PLL_B,
-			.source = SI5351C_SRC_MULTISYNTH_SELF,
-			.drive = SI5351C_DRIVE_4MA,
-		};
-		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
-			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
-			clk[2] = (si5351c_clk_ctrl_t){
-				.mode = SI5351C_MODE_FRAC,
-				.pll = SI5351C_PLL_A,
-				.source = SI5351C_SRC_MULTISYNTH_SELF,
-				.drive = SI5351C_DRIVE_2MA,
-			};
-		} else {
-			/* CLK2: MCU_CLK */
-			clk[2] = powered_down;
-		}
-	}
-#endif
-
 	for (int i = 0; i < 8; i++) {
 		set_CLK_PDN(drv, i, clk[i].power_down);
 		set_MS_INT(drv, i, clk[i].mode);
@@ -417,72 +279,19 @@ void si5351c_configure_clock_control(si5351c_driver_t* const drv)
 
 void si5351c_enable_clock_outputs(si5351c_driver_t* const drv)
 {
-	/* Enable CLK outputs 0, 1, 2, 4, 5 only. */
-	/* Praline: enable 0, 1, 4, 5 only. */
-	/* 7: Clock to CPU is deactivated as it is not used and creates noise */
-	/* 3: External clock output is deactivated by default */
-
-	uint8_t clkout = 3;
-
-	bool enable[8];
-
-#ifdef IS_PRALINE
-	if (IS_PRALINE) {
-		enable[0] = true;
-		enable[1] = true;
-		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
-			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
-			enable[2] = true;
-		} else {
-			enable[2] = false;
-		}
-		enable[3] = false;
-		enable[4] = true;
-		enable[5] = true;
-		enable[6] = false;
-		enable[7] = false;
-	}
-#endif
-#ifdef IS_NOT_PRALINE
-	if (IS_NOT_PRALINE) {
-		enable[0] = true;
-		enable[1] = true;
-		enable[2] = true;
-		enable[3] = false;
-		enable[4] = true;
-		enable[5] = true;
-		enable[6] = false;
-		enable[7] = false;
-
-		/* HackRF One r9 has only three clock generator outputs. */
-	#ifdef IS_H1_R9
-		if (IS_H1_R9) {
-			clkout = 2;
-			enable[0] = true;
-			enable[1] = true;
-			enable[3] = false;
-			enable[4] = false;
-			enable[5] = false;
-			enable[6] = false;
-			enable[7] = false;
-		}
-	#endif
-	}
-#endif
-	enable[clkout] = clkout_enabled;
-
 	for (int i = 0; i < 8; i++) {
 		set_CLK_OEB(
 			drv,
 			i,
-			enable[i] ? SI5351C_OUTPUT_ENABLE : SI5351C_OUTPUT_DISABLE);
+			clk[i].output_enable ? SI5351C_OUTPUT_ENABLE :
+					       SI5351C_OUTPUT_DISABLE);
 	}
 	si5351c_regs_commit(drv);
 
 #ifdef IS_H1_R9
 	if (IS_H1_R9) {
 		const platform_gpio_t* gpio = platform_gpio();
-		if (clkout_enabled) {
+		if (clk[clkout_id].output_enable) {
 			gpio_set(gpio->h1r9_clkout_en);
 		} else {
 			gpio_clear(gpio->h1r9_clkout_en);
@@ -545,16 +354,11 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv)
 
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable)
 {
-	clkout_enabled = enable;
+	clk[clkout_id].output_enable = enable;
+	clk[clkout_id].power_down = !enable;
 
-	uint8_t clkout = 3;
-
-	/* HackRF One r9 has only three clock generator outputs. */
-	if (detected_platform() == BOARD_ID_HACKRF1_R9) {
-		clkout = 2;
-	}
 	/* Configure clock to 10MHz */
-	si5351c_configure_multisynth(drv, clkout, 80 * 128 - 512, 0, 1, 0);
+	si5351c_configure_multisynth(drv, clkout_id, 80 * 128 - 512, 0, 1, 0);
 
 	si5351c_configure_clock_control(drv);
 	si5351c_enable_clock_outputs(drv);
@@ -618,6 +422,155 @@ void si5351c_init(si5351c_driver_t* const drv)
 		scu_pinmux(scu->H1R9_MCU_CLK_EN, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
 		gpio_clear(gpio->h1r9_mcu_clk_en);
 		gpio_output(gpio->h1r9_mcu_clk_en);
+	}
+#endif
+
+	si5351c_clk_t clkout = {
+		.output_enable = false,
+		.power_down = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_8MA,
+	};
+
+	si5351c_clk_t powered_down = {
+		.output_enable = false,
+		.power_down = true,
+		.mode = SI5351C_MODE_INT,
+	};
+
+	/* CLK0: MAX5864/CPLD */
+	clk[0] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_FRAC,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_8MA,
+	};
+	/* CLK1: CPLD */
+	clk[1] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_0_4,
+		.drive = SI5351C_DRIVE_2MA,
+		.invert = true,
+	};
+	/* CLK2: SGPIO */
+	clk[2] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_0_4,
+		.drive = SI5351C_DRIVE_2MA,
+	};
+	/* CLK3: CLKOUT */
+	clk[3] = clkout;
+	clkout_id = 3;
+	/* CLK4: RFFC5072 (MAX2837 on rad1o) */
+	clk[4] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_6MA,
+		.invert = true,
+	};
+	/* CLK5: MAX2837 (MAX2871 on rad1o) */
+	clk[5] = (si5351c_clk_t){
+		.output_enable = true,
+		.mode = SI5351C_MODE_INT,
+		.pll = SI5351C_PLL_A,
+		.source = SI5351C_SRC_MULTISYNTH_SELF,
+		.drive = SI5351C_DRIVE_4MA,
+	};
+	/* CLK6: none */
+	clk[6] = powered_down;
+	/* CLK7: LPC43xx */
+	clk[7] = powered_down;
+
+#ifdef IS_H1_R9
+	if (IS_H1_R9) {
+		/* CLK0: MAX5864/CPLD/SGPIO (sample clocks) */
+		clk[0] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_INT,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_6MA,
+		};
+		/* CLK1: RFFC5072/MAX2839 */
+		clk[1] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_FRAC,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+		};
+		/* CLK2: CLKOUT/LPC4320 */
+		clk[2] = clkout;
+		clkout_id = 2;
+		/* Other outputs not present on Si5351A */
+		clk[3] = powered_down;
+		clk[4] = powered_down;
+		clk[5] = powered_down;
+		clk[6] = powered_down;
+		clk[7] = powered_down;
+	}
+#endif
+#ifdef IS_PRALINE
+	if (IS_PRALINE) {
+		/* CLK0: AFE_CLK */
+		clk[0] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_FRAC,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+		};
+		/* CLK1: SCT_CLK and FPGA_CLK */
+		clk[1] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_FRAC,
+			.pll = SI5351C_PLL_A,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_2MA,
+		};
+		/* CLK3: CLKOUT */
+		clkout.pll = SI5351C_PLL_B;
+		clk[3] = clkout;
+		clkout_id = 3;
+		/* CLK4: XCVR_CLK */
+		clk[4] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_INT,
+			.pll = SI5351C_PLL_B,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+			.invert = true,
+		};
+		/* CLK5: MIX_CLK */
+		clk[5] = (si5351c_clk_t){
+			.output_enable = true,
+			.mode = SI5351C_MODE_INT,
+			.pll = SI5351C_PLL_B,
+			.source = SI5351C_SRC_MULTISYNTH_SELF,
+			.drive = SI5351C_DRIVE_4MA,
+		};
+		if ((detected_revision() & ~BOARD_REV_GSG) < BOARD_REV_PRALINE_R1_1) {
+			/* CLK2: FPGA_CLK (not shared with SCT_CLK on older boards) */
+			clk[2] = (si5351c_clk_t){
+				.output_enable = true,
+				.mode = SI5351C_MODE_FRAC,
+				.pll = SI5351C_PLL_A,
+				.source = SI5351C_SRC_MULTISYNTH_SELF,
+				.drive = SI5351C_DRIVE_2MA,
+			};
+		} else {
+			/* CLK2: MCU_CLK */
+			clk[2] = powered_down;
+		}
 	}
 #endif
 }

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -135,6 +135,7 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv);
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val);
 uint8_t si5351c_read_single(si5351c_driver_t* const drv, uint8_t reg);
 void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable);
+void si5351c_mcu_clkin_enable(si5351c_driver_t* const drv, bool enable);
 void si5351c_init(si5351c_driver_t* const drv);
 void si5351c_set_phase(
 	si5351c_driver_t* const drv,

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -103,6 +103,10 @@ typedef struct {
 	i2c_bus_t* const bus;
 	uint8_t i2c_address;
 	si5351c_clk_t clk[8];
+	uint8_t clkout_id;
+	uint8_t mcu_clkin_id;
+	bool input_initialized;
+	si5351c_input_t active_input;
 	uint8_t regs[SI5351C_CACHED_REGS];
 	uint32_t regs_dirty[(SI5351C_CACHED_REGS + 31) / 32];
 } si5351c_driver_t;

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -133,7 +133,7 @@ bool si5351c_clkin_signal_valid(si5351c_driver_t* const drv);
 
 void si5351c_write_single(si5351c_driver_t* const drv, uint8_t reg, uint8_t val);
 uint8_t si5351c_read_single(si5351c_driver_t* const drv, uint8_t reg);
-void si5351c_clkout_enable(si5351c_driver_t* const drv, uint8_t enable);
+void si5351c_clkout_enable(si5351c_driver_t* const drv, bool enable);
 void si5351c_init(si5351c_driver_t* const drv);
 void si5351c_set_phase(
 	si5351c_driver_t* const drv,

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -90,13 +90,6 @@ typedef enum {
 } si5351c_input_t;
 
 typedef struct {
-	i2c_bus_t* const bus;
-	uint8_t i2c_address;
-	uint8_t regs[SI5351C_CACHED_REGS];
-	uint32_t regs_dirty[(SI5351C_CACHED_REGS + 31) / 32];
-} si5351c_driver_t;
-
-typedef struct {
 	bool output_enable;
 	bool power_down;
 	si5351c_mode_t mode;
@@ -105,6 +98,14 @@ typedef struct {
 	si5351c_drive_t drive;
 	bool invert;
 } si5351c_clk_t;
+
+typedef struct {
+	i2c_bus_t* const bus;
+	uint8_t i2c_address;
+	si5351c_clk_t clk[8];
+	uint8_t regs[SI5351C_CACHED_REGS];
+	uint32_t regs_dirty[(SI5351C_CACHED_REGS + 31) / 32];
+} si5351c_driver_t;
 
 void si5351c_disable_all_outputs(si5351c_driver_t* const drv);
 void si5351c_disable_oeb_pin_control(si5351c_driver_t* const drv);

--- a/firmware/common/si5351c.h
+++ b/firmware/common/si5351c.h
@@ -97,13 +97,14 @@ typedef struct {
 } si5351c_driver_t;
 
 typedef struct {
+	bool output_enable;
 	bool power_down;
 	si5351c_mode_t mode;
 	si5351c_pll_t pll;
 	si5351c_src_t source;
 	si5351c_drive_t drive;
 	bool invert;
-} si5351c_clk_ctrl_t;
+} si5351c_clk_t;
 
 void si5351c_disable_all_outputs(si5351c_driver_t* const drv);
 void si5351c_disable_oeb_pin_control(si5351c_driver_t* const drv);

--- a/firmware/common/spi_bus.c
+++ b/firmware/common/spi_bus.c
@@ -22,27 +22,6 @@
 
 #include "spi_bus.h"
 
-#include <libopencm3/lpc43xx/memorymap.h>
-
-#include "spi_ssp.h"
-
-/* Driver instances. */
-spi_bus_t spi_bus_ssp0 = {
-	.obj = (void*) SSP0_BASE,
-	.start = spi_ssp_start,
-	.stop = spi_ssp_stop,
-	.transfer = spi_ssp_transfer,
-	.transfer_gather = spi_ssp_transfer_gather,
-};
-
-spi_bus_t spi_bus_ssp1 = {
-	.obj = (void*) SSP1_BASE,
-	.start = spi_ssp_start,
-	.stop = spi_ssp_stop,
-	.transfer = spi_ssp_transfer,
-	.transfer_gather = spi_ssp_transfer_gather,
-};
-
 void spi_bus_start(spi_bus_t* const bus, const void* const config)
 {
 	bus->config = config;

--- a/firmware/common/spi_bus.c
+++ b/firmware/common/spi_bus.c
@@ -31,17 +31,29 @@ void spi_bus_start(spi_bus_t* const bus, const void* const config)
 void spi_bus_stop(spi_bus_t* const bus)
 {
 	bus->stop(bus);
+	bus->config = NULL;
 }
 
-void spi_bus_transfer(spi_bus_t* const bus, void* const data, const size_t count)
+void spi_bus_transfer(
+	spi_bus_t* const bus,
+	const void* const config,
+	void* const data,
+	const size_t count)
 {
+	if (config != bus->config) {
+		spi_bus_start(bus, config);
+	}
 	bus->transfer(bus, data, count);
 }
 
 void spi_bus_transfer_gather(
 	spi_bus_t* const bus,
+	const void* const config,
 	const spi_transfer_t* const transfers,
 	const size_t count)
 {
+	if (config != bus->config) {
+		spi_bus_start(bus, config);
+	}
 	bus->transfer_gather(bus, transfers, count);
 }

--- a/firmware/common/spi_bus.h
+++ b/firmware/common/spi_bus.h
@@ -51,7 +51,3 @@ void spi_bus_transfer_gather(
 	spi_bus_t* const bus,
 	const spi_transfer_t* const transfers,
 	const size_t count);
-
-/* Driver instances. */
-extern spi_bus_t spi_bus_ssp0;
-extern spi_bus_t spi_bus_ssp1;

--- a/firmware/common/spi_bus.h
+++ b/firmware/common/spi_bus.h
@@ -46,8 +46,13 @@ typedef struct _spi_bus_t {
 
 void spi_bus_start(spi_bus_t* const bus, const void* const config);
 void spi_bus_stop(spi_bus_t* const bus);
-void spi_bus_transfer(spi_bus_t* const bus, void* const data, const size_t count);
+void spi_bus_transfer(
+	spi_bus_t* const bus,
+	const void* const config,
+	void* const data,
+	const size_t count);
 void spi_bus_transfer_gather(
 	spi_bus_t* const bus,
+	const void* const config,
 	const spi_transfer_t* const transfers,
 	const size_t count);

--- a/firmware/common/spi_ssp.c
+++ b/firmware/common/spi_ssp.c
@@ -28,6 +28,23 @@
 #include <libopencm3/lpc43xx/rgu.h>
 #include <libopencm3/lpc43xx/ssp.h>
 
+/* Driver instances. */
+spi_bus_t spi_bus_ssp0 = {
+	.obj = (void*) SSP0_BASE,
+	.start = spi_ssp_start,
+	.stop = spi_ssp_stop,
+	.transfer = spi_ssp_transfer,
+	.transfer_gather = spi_ssp_transfer_gather,
+};
+
+spi_bus_t spi_bus_ssp1 = {
+	.obj = (void*) SSP1_BASE,
+	.start = spi_ssp_start,
+	.stop = spi_ssp_stop,
+	.transfer = spi_ssp_transfer,
+	.transfer_gather = spi_ssp_transfer_gather,
+};
+
 void spi_ssp_start(spi_bus_t* const bus, const void* const _config)
 {
 	const ssp_config_t* const config = _config;

--- a/firmware/common/spi_ssp.h
+++ b/firmware/common/spi_ssp.h
@@ -45,3 +45,7 @@ void spi_ssp_transfer_gather(
 	spi_bus_t* const bus,
 	const spi_transfer_t* const transfers,
 	const size_t count);
+
+/* Driver instances. */
+extern spi_bus_t spi_bus_ssp0;
+extern spi_bus_t spi_bus_ssp1;

--- a/firmware/common/ui_rad1o.c
+++ b/firmware/common/ui_rad1o.c
@@ -26,7 +26,6 @@
 #include <stdint.h>
 
 #include "clock_gen.h"
-#include "max283x.h"
 #include "rf_path.h"
 #include "transceiver_mode.h"
 
@@ -195,9 +194,6 @@ static void ui_update(void)
 	rad1o_lcdNl();
 
 	rad1o_lcdDisplay();
-
-	// Don't ask...
-	ssp1_set_mode_max283x();
 }
 
 static void rad1o_ui_init(void)
@@ -211,8 +207,6 @@ static void rad1o_ui_deinit(void)
 {
 	rad1o_lcdDeInit();
 	enabled = false;
-	// Don't ask...
-	ssp1_set_mode_max283x();
 }
 
 static void rad1o_ui_set_frequency(uint64_t frequency)

--- a/firmware/common/w25q80bv.c
+++ b/firmware/common/w25q80bv.c
@@ -35,6 +35,7 @@
 #include <libopencm3/lpc43xx/ssp.h>
 
 #include "platform_detect.h"
+#include "platform_gpio.h"
 #include "w25q80bv_target.h"
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
@@ -90,6 +91,11 @@ static void w25q80bv_transfer_gather(
 void w25q80bv_setup(w25q80bv_driver_t* const drv)
 {
 	uint8_t device_id;
+	const platform_gpio_t* gpio = platform_gpio();
+
+	ssp_config_w25q80bv.gpio_select = gpio->w25q80bv_select;
+	spi_flash.gpio_hold = gpio->w25q80bv_hold;
+	spi_flash.gpio_wp = gpio->w25q80bv_wp;
 
 	drv->page_len = 256U;
 	if (detected_platform() == BOARD_ID_PRALINE) {

--- a/firmware/common/w25q80bv.c
+++ b/firmware/common/w25q80bv.c
@@ -67,6 +67,22 @@ w25q80bv_driver_t spi_flash = {
 	.target_init = w25q80bv_target_init,
 };
 
+static void w25q80bv_transfer(
+	w25q80bv_driver_t* const drv,
+	void* const data,
+	const size_t count)
+{
+	spi_bus_transfer(drv->bus, &ssp_config_w25q80bv, data, count);
+}
+
+static void w25q80bv_transfer_gather(
+	w25q80bv_driver_t* const drv,
+	const spi_transfer_t* const transfers,
+	size_t size)
+{
+	spi_bus_transfer_gather(drv->bus, &ssp_config_w25q80bv, transfers, size);
+}
+
 /*
  * Set up pins for GPIO and SPI control, configure SSP0 peripheral for SPI.
  * SSP0_CS is controlled by GPIO in order to handle various transfer lengths.
@@ -96,7 +112,7 @@ void w25q80bv_setup(w25q80bv_driver_t* const drv)
 uint8_t w25q80bv_get_status(w25q80bv_driver_t* const drv)
 {
 	uint8_t data[] = {W25Q80BV_READ_STATUS1, 0xFF};
-	spi_bus_transfer(drv->bus, data, ARRAY_SIZE(data));
+	w25q80bv_transfer(drv, data, ARRAY_SIZE(data));
 	return data[1];
 }
 
@@ -104,7 +120,7 @@ uint8_t w25q80bv_get_status(w25q80bv_driver_t* const drv)
 uint8_t w25q80bv_get_device_id(w25q80bv_driver_t* const drv)
 {
 	uint8_t data[] = {W25Q80BV_DEVICE_ID, 0xFF, 0xFF, 0xFF, 0xFF};
-	spi_bus_transfer(drv->bus, data, ARRAY_SIZE(data));
+	w25q80bv_transfer(drv, data, ARRAY_SIZE(data));
 	return data[4];
 }
 
@@ -124,7 +140,7 @@ void w25q80bv_get_unique_id(w25q80bv_driver_t* const drv, w25q80bv_unique_id_t* 
 		0xFF,
 		0xFF,
 		0xFF};
-	spi_bus_transfer(drv->bus, data, ARRAY_SIZE(data));
+	w25q80bv_transfer(drv, data, ARRAY_SIZE(data));
 
 	for (size_t i = 0; i < 8; i++) {
 		unique_id->id_8b[i] = data[5 + i];
@@ -141,7 +157,7 @@ void w25q80bv_write_enable(w25q80bv_driver_t* const drv)
 	w25q80bv_wait_while_busy(drv);
 
 	uint8_t data[] = {W25Q80BV_WRITE_ENABLE};
-	spi_bus_transfer(drv->bus, data, ARRAY_SIZE(data));
+	w25q80bv_transfer(drv, data, ARRAY_SIZE(data));
 	while (!(w25q80bv_get_status(drv) & W25Q80BV_STATUS_WEL)) {}
 }
 
@@ -159,7 +175,7 @@ void w25q80bv_chip_erase(w25q80bv_driver_t* const drv)
 	w25q80bv_write_enable(drv);
 
 	uint8_t data[] = {W25Q80BV_CHIP_ERASE};
-	spi_bus_transfer(drv->bus, data, ARRAY_SIZE(data));
+	w25q80bv_transfer(drv, data, ARRAY_SIZE(data));
 }
 
 /* write up a 256 byte page or partial page */
@@ -190,7 +206,7 @@ static void w25q80bv_page_program(
 
 	const spi_transfer_t transfers[] = {{header, ARRAY_SIZE(header)}, {data, len}};
 
-	spi_bus_transfer_gather(drv->bus, transfers, ARRAY_SIZE(transfers));
+	w25q80bv_transfer_gather(drv, transfers, ARRAY_SIZE(transfers));
 }
 
 /* write an arbitrary number of bytes */
@@ -265,7 +281,7 @@ void w25q80bv_read(
 
 	const spi_transfer_t transfers[] = {{header, ARRAY_SIZE(header)}, {data, len}};
 
-	spi_bus_transfer_gather(drv->bus, transfers, ARRAY_SIZE(transfers));
+	w25q80bv_transfer_gather(drv, transfers, ARRAY_SIZE(transfers));
 }
 
 void w25q80bv_clear_status(w25q80bv_driver_t* const drv)
@@ -273,16 +289,16 @@ void w25q80bv_clear_status(w25q80bv_driver_t* const drv)
 	w25q80bv_wait_while_busy(drv);
 	w25q80bv_write_enable(drv);
 	uint8_t data[] = {W25Q80BV_WRITE_STATUS, 0x00, 0x00};
-	spi_bus_transfer(drv->bus, data, ARRAY_SIZE(data));
+	w25q80bv_transfer(drv, data, ARRAY_SIZE(data));
 }
 
 void w25q80bv_get_full_status(w25q80bv_driver_t* const drv, uint8_t* data)
 {
 	uint8_t cmd[] = {W25Q80BV_READ_STATUS1, 0xFF};
-	spi_bus_transfer(drv->bus, cmd, ARRAY_SIZE(cmd));
+	w25q80bv_transfer(drv, cmd, ARRAY_SIZE(cmd));
 	data[0] = cmd[1];
 	cmd[0] = W25Q80BV_READ_STATUS2;
 	cmd[1] = 0xFF;
-	spi_bus_transfer(drv->bus, cmd, ARRAY_SIZE(cmd));
+	w25q80bv_transfer(drv, cmd, ARRAY_SIZE(cmd));
 	data[1] = cmd[1];
 }

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -37,6 +37,7 @@
 #include <hackrf_ui.h>
 #include <leds.h>
 #include <operacake.h>
+#include <mixer.h>
 #include <pins.h>
 #include <platform_detect.h>
 #include <power.h>
@@ -56,7 +57,6 @@
 	#include <portapack.h>
 #endif
 #ifdef IS_NOT_RAD1O
-	#include <mixer.h>
 	#include <rffc5071.h>
 #endif
 #ifdef IS_PRALINE
@@ -436,6 +436,7 @@ int main(void)
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
+	mixer_bus_setup(&mixer);
 	sgpio_configure_pin_functions(&sgpio_config);
 	rf_path_pin_setup(&rf_path);
 #ifdef IS_PRALINE

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -433,7 +433,7 @@ int main(void)
 	if (board_id != BOARD_ID_RAD1O) {
 		clock_gen_shutdown();
 	}
-	delay_us_at_mhz(10000, 96);
+	delay_ms(10);
 	pins_setup();
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
@@ -491,7 +491,7 @@ int main(void)
 #ifdef IS_NOT_PRALINE
 	if (IS_NOT_PRALINE) {
 		if (!cpld_jtag_sram_load(&jtag_cpld)) {
-			halt_and_flash(6000000);
+			halt_and_flash(1000);
 		}
 	}
 #endif
@@ -503,7 +503,7 @@ int main(void)
 	#else
 		fpga_image_load(&fpga_loader, 0);
 	#endif
-		delay_us_at_mhz(100, 204);
+		delay_us(100);
 		fpga_spi_selftest();
 		fpga_sgpio_selftest();
 	}

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -275,7 +275,6 @@ extern uint32_t _binary_fpga_bin_start;
 
 void fpga_loader_setup(void)
 {
-	spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 	w25q80bv_setup(&spi_flash);
 }
 

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -429,11 +429,13 @@ int main(void)
 	board_id_t board_id = detected_platform();
 
 	pins_shutdown();
+	sgpio_pin_shutdown(&sgpio_config);
 	if (board_id != BOARD_ID_RAD1O) {
 		clock_gen_shutdown();
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
+	sgpio_configure_pin_functions(&sgpio_config);
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		enable_3v3aux_power();

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -30,6 +30,7 @@
 
 #include <clock_gen.h>
 #include <clock_io.h>
+#include <cpld_jtag.h>
 #include <cpu_clock.h>
 #include <da7219.h>
 #include <delay.h>
@@ -66,9 +67,6 @@
 		#include <spi_bus.h>
 		#include <w25q80bv.h>
 	#endif
-#endif
-#ifdef IS_NOT_PRALINE
-	#include <cpld_jtag.h>
 #endif
 
 #include "usb_api_adc.h"
@@ -436,6 +434,7 @@ int main(void)
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
+	cpld_jtag_pin_setup();
 	mixer_bus_setup(&mixer);
 	sgpio_configure_pin_functions(&sgpio_config);
 	rf_path_pin_setup(&rf_path);

--- a/firmware/hackrf_usb/hackrf_usb.c
+++ b/firmware/hackrf_usb/hackrf_usb.c
@@ -430,12 +430,14 @@ int main(void)
 
 	pins_shutdown();
 	sgpio_pin_shutdown(&sgpio_config);
+	rf_path_pin_shutdown();
 	if (board_id != BOARD_ID_RAD1O) {
 		clock_gen_shutdown();
 	}
 	delay_us_at_mhz(10000, 96);
 	pins_setup();
 	sgpio_configure_pin_functions(&sgpio_config);
+	rf_path_pin_setup(&rf_path);
 #ifdef IS_PRALINE
 	if (IS_PRALINE) {
 		enable_3v3aux_power();

--- a/firmware/hackrf_usb/usb_api_board_info.c
+++ b/firmware/hackrf_usb/usb_api_board_info.c
@@ -30,6 +30,7 @@
 #include <firmware_info.h>
 #include <pins.h>
 #include <platform_detect.h>
+#include <rf_path.h>
 #include <rom_iap.h>
 #include <sgpio.h>
 #include <usb_queue.h>
@@ -132,6 +133,7 @@ usb_request_status_t usb_vendor_request_reset(
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		pins_shutdown();
 		sgpio_pin_shutdown(&sgpio_config);
+		rf_path_pin_shutdown();
 		clock_gen_shutdown();
 #ifdef IS_H1_R9
 		if (IS_H1_R9) {

--- a/firmware/hackrf_usb/usb_api_board_info.c
+++ b/firmware/hackrf_usb/usb_api_board_info.c
@@ -31,6 +31,7 @@
 #include <pins.h>
 #include <platform_detect.h>
 #include <rom_iap.h>
+#include <sgpio.h>
 #include <usb_queue.h>
 #include <usb_request.h>
 #include <usb_type.h>
@@ -130,6 +131,7 @@ usb_request_status_t usb_vendor_request_reset(
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
 		pins_shutdown();
+		sgpio_pin_shutdown(&sgpio_config);
 		clock_gen_shutdown();
 #ifdef IS_H1_R9
 		if (IS_H1_R9) {

--- a/firmware/hackrf_usb/usb_api_cpld.c
+++ b/firmware/hackrf_usb/usb_api_cpld.c
@@ -76,7 +76,7 @@ void cpld_update(void)
 		cpld_xsvf_buffer,
 		refill_cpld_buffer);
 	if (error == 0) {
-		halt_and_flash(6000000);
+		halt_and_flash(1000);
 	} else {
 		/* LED3 (Red) steady on error */
 		led_on(LED3);

--- a/firmware/hackrf_usb/usb_api_register.c
+++ b/firmware/hackrf_usb/usb_api_register.c
@@ -211,7 +211,7 @@ usb_request_status_t usb_vendor_request_set_clkout_enable(
 	const usb_transfer_stage_t stage)
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		si5351c_clkout_enable(&si5351c, endpoint->setup.value);
+		si5351c_clkout_enable(&si5351c, endpoint->setup.value > 0);
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;

--- a/firmware/hackrf_usb/usb_api_spiflash.c
+++ b/firmware/hackrf_usb/usb_api_spiflash.c
@@ -26,7 +26,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <spi_bus.h>
 #include <usb_queue.h>
 #include <usb_request.h>
 #include <usb_type.h>
@@ -40,7 +39,6 @@ usb_request_status_t usb_vendor_request_erase_spiflash(
 	const usb_transfer_stage_t stage)
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 		w25q80bv_setup(&spi_flash);
 		/* only chip erase is implemented */
 		w25q80bv_chip_erase(&spi_flash);
@@ -69,7 +67,6 @@ usb_request_status_t usb_vendor_request_write_spiflash(
 				len,
 				NULL,
 				NULL);
-			spi_bus_start(spi_flash.bus, &ssp_config_w25q80bv);
 			w25q80bv_setup(&spi_flash);
 			return USB_REQUEST_STATUS_OK;
 		}


### PR DESCRIPTION
Merge from upstream.

Fixed following conflicts:

1. Resolved the conflict block: kept the fork's screen_width/screen_height globals (still used by the fork's portarf display detection at portapack_lcd_init and portapack_backlight_set) and dropped portapack_sleep_milliseconds(). Upstream's commit b86b1393 ("Express all delays as delay_us() or delay_ms()") replaced all its call sites with delay_ms(), so it would have been an unused static function.
  2. Fixed a latent build break the conflict markers didn't cover: that same upstream commit deleted the plain delay() function entirely, but four fork-only call sites (the LCD read-timing waits in portapack_lcd_read_2byte and the portarf init delays) still used it. I converted them behavior-preservingly using the old helper's scale (delay(x * 40800) ≈ x ms → delay_us(x *  1000)): delay_us(355), delay_us(90), delay_us(120), delay_us(50).

:warning:  One thing worth knowing: the old trailing comments on those last two calls claimed "120ms" and "50ms", but the actual delay the code produced was 120µs/50µs (the fork worked with that on hardware, so I preserved it). If the portarf display ever shows init issues, bumping those to delay_ms(120)/delay_ms(50) to match the ILI9488 sleep-out spec would be the fix.